### PR TITLE
feat: aws-session-token

### DIFF
--- a/actions/deploy-ecs/action.yml
+++ b/actions/deploy-ecs/action.yml
@@ -7,6 +7,9 @@ inputs:
   aws-secret-access-key:
     description: 'The AWS secret access key'
     required: true
+  aws-session-token:
+    description: 'The AWS session token'
+    required: false
   aws-region:
     description: 'The AWS region to deploy to'
     required: true
@@ -31,6 +34,7 @@ runs:
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Download task definition

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -15,6 +15,9 @@ inputs:
   aws-secret-access-key:
     description: 'The AWS secret access key'
     required: true
+  aws-session-token:
+    description: 'The AWS session token'
+    required: false
   aws-region:
     description: 'The AWS region to deploy to'
     required: true
@@ -61,6 +64,7 @@ runs:
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         aws-region: ${{ inputs.aws-region }}
     - name: Get Grafana Details
       id: get-grafana-key

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -15,6 +15,9 @@ inputs:
   aws-secret-access-key:
     description: 'The AWS secret access key'
     required: true
+  aws-session-token:
+    description: 'The AWS session token'
+    required: false
   aws-region:
     description: 'The AWS region to deploy to'
     required: true
@@ -55,6 +58,7 @@ runs:
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         aws-region: ${{ inputs.aws-region }}
     - name: Get Grafana Details
       id: get-grafana-key


### PR DESCRIPTION
This passes the aws-session-token environment variable in-case the actions are being tested locally via act.

Tested `deploy-terraform` in https://github.com/WalletConnect/data-lake-api/pull/32