### PR TITLE
fix: adding package name to the sed substitution

### DIFF
--- a/github/update-rust-version/action.yml
+++ b/github/update-rust-version/action.yml
@@ -29,8 +29,9 @@ runs:
       shell: bash
       run: |
         version=$(echo "${{ steps.release.outputs.version }}" | sed 's/v//g')
+        package_name=$(sed -n 's/^name = "\(.*\)"/\1/p' ./Cargo.toml)
         sed "s/^version = \".*\"\$/version = \"$version\"/" ./Cargo.toml > /tmp/cargo.toml
-        sed "/^name = \"keyserver\"\$/{ n; s/^version = \".*\"\$/version = \"$version\"/g }" ./Cargo.lock > /tmp/cargo.lock
+        sed -e "/^name = \"$package_name\"\$/{ n; s/^version = \".*\"\$/version = \"$version\"/g; }" ./Cargo.lock > /tmp/cargo.lock
         mv /tmp/cargo.toml ./Cargo.toml
         mv /tmp/cargo.lock ./Cargo.lock
 


### PR DESCRIPTION
### Description
This PR changes the substitution for the version bumping in the `Cargo.lock` to fix the bug with the hardcoded `keyserver` package name:
 - Adding extraction of the package name from the `Cargo.toml` to the variable;
 - Using the package name for the substitution of the version;
 - Adding `-e` flag to the sed to use the expression on all platforms as it requires `-e` in mac.

Resolves #20 

### Test plan

Fill test files by calling the following commands:
```
echo "[package]
name = \"echo-server\"
version = \"0.34.7\"
edition = \"2021\"" >> Cargo.toml

echo "[[package]]
name = \"echo-server\"
version = \"0.34.7\"" >> Cargo.lock
```

Call the bash script which is identical to that we are using in `run`:

```
version=$(echo "0.99.99" | sed 's/v//g')
package_name=$(sed -n 's/^name = "\(.*\)"/\1/p' ./Cargo.toml)
sed "s/^version = \".*\"\$/version = \"$version\"/" ./Cargo.toml > /tmp/cargo.toml
sed -e "/^name = \"$package_name\"\$/{ n; s/^version = \".*\"\$/version = \"$version\"/g; }" ./Cargo.lock > /tmp/cargo.lock
mv /tmp/cargo.toml ./Cargo.toml
mv /tmp/cargo.lock ./Cargo.lock
```

The version should be replaced with `0.99.99` in `Cargo.toml` and `Cargo.lock`.