### PR TITLE
fix(terraform): fixes passing of TFC token, grafana key, selecting workspace

### DIFF
--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -53,12 +53,18 @@ inputs:
     description: 'SSH key to fetch private Terraform modules'
     required: false
     default: ''
+  tfc_token:
+    description: 'Terraform Cloud API Token'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
+      with:
+        cli_config_credentials_token: ${{ inputs.tfc_token }}
     - uses: actions/setup-python@v5
       if: ${{ inputs.needs-python == 'true' }}
       with:

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -101,10 +101,10 @@ runs:
       id: init
       shell: bash
       env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
+        TF_VAR_grafana_auth: ${{ INPUTS.GRAFANA-API-KEY != '' && INPUTS.GRAFANA-API-KEY || STEPS.GET-GRAFANA-KEY.OUTPUTS.KEY }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |
@@ -118,10 +118,10 @@ runs:
       id: apply
       shell: bash
       env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
+        TF_VAR_grafana_auth: ${{ INPUTS.GRAFANA-API-KEY != '' && INPUTS.GRAFANA-API-KEY || STEPS.GET-GRAFANA-KEY.OUTPUTS.KEY }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -97,39 +97,42 @@ runs:
       uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ inputs.ssh-key }}
+    - name: Configure Terraform Variables
+      shell: bash
+      working-directory: ${{ inputs.terraform-path }}
+      run: |
+        echo 'grafana_auth="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"' >> "${{ inputs.environment }}.auto.tfvars"
     - name: Terraform Init
       id: init
       shell: bash
+      working-directory: ${{ inputs.terraform-path }}
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TF_VAR_grafana_auth: ${{ INPUTS.GRAFANA-API-KEY != '' && INPUTS.GRAFANA-API-KEY || STEPS.GET-GRAFANA-KEY.OUTPUTS.KEY }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
+        TF_INPUT: 0
       run: |
         VAR_FILE="vars/${{ inputs.environment }}.tfvars"
         if [ -f "$VAR_FILE" ]; then
-          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false -var-file="$VAR_FILE"
+          terraform init -no-color -var-file="$VAR_FILE"
         else
-          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+          terraform init -no-color
         fi
     - name: Terraform Apply
       id: apply
       shell: bash
+      working-directory: ${{ inputs.terraform-path }}
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TF_VAR_grafana_auth: ${{ INPUTS.GRAFANA-API-KEY != '' && INPUTS.GRAFANA-API-KEY || STEPS.GET-GRAFANA-KEY.OUTPUTS.KEY }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
+        TF_INPUT: 0
       run: |
         VAR_FILE="vars/${{ inputs.environment }}.tfvars"
         if [ -f "$VAR_FILE" ]; then
-          terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false -var-file="$VAR_FILE"
+          terraform apply -auto-approve -no-color -var-file="$VAR_FILE"
         else
-          terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false
+          terraform apply -auto-approve -no-color
         fi
     - name: Reset Grafana Details
       id: delete-grafana-key

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -101,7 +101,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.terraform-path }}
       run: |
-        echo 'grafana_auth="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"' >> "${{ inputs.environment }}.auto.tfvars"
+        # Mask the sensitive key output
+        grafana_auth_key="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"
+        echo "::add-mask::$grafana_auth_key"
+        
+        # Append the key to the .auto.tfvars file
+        echo "grafana_auth=\"$grafana_auth_key\"" >> "${{ inputs.environment }}.auto.tfvars"
     - name: Terraform Init
       id: init
       shell: bash

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -107,7 +107,7 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false
+      run: terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
     - name: Terraform Apply
       id: apply
       shell: bash
@@ -118,7 +118,7 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH apply -var-file="vars/${{ inputs.environment }}.tfvars" -auto-approve -no-color -input=false
+      run: terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false
     - name: Reset Grafana Details
       id: delete-grafana-key
       if: ${{ always() && inputs.app-name != '' }}

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -106,17 +106,8 @@ runs:
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
-      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color
-    - name: Terraform Select Workspace
-      id: workspace
-      shell: bash
-      env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
-        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
-        OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
-      run: terraform -chdir=$TERRAFORM_PATH workspace select -or-create=true ${{ inputs.environment }}
+        TF_WORKSPACE: ${{ inputs.environment }}
+      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false
     - name: Terraform Apply
       id: apply
       shell: bash
@@ -126,6 +117,7 @@ runs:
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
+        TF_WORKSPACE: ${{ inputs.environment }}
       run: terraform -chdir=$TERRAFORM_PATH apply -var-file="vars/${{ inputs.environment }}.tfvars" -auto-approve -no-color -input=false
     - name: Reset Grafana Details
       id: delete-grafana-key

--- a/actions/deploy-terraform/action.yml
+++ b/actions/deploy-terraform/action.yml
@@ -107,7 +107,13 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+      run: |
+        VAR_FILE="vars/${{ inputs.environment }}.tfvars"
+        if [ -f "$VAR_FILE" ]; then
+          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false -var-file="$VAR_FILE"
+        else
+          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+        fi
     - name: Terraform Apply
       id: apply
       shell: bash
@@ -118,7 +124,13 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false
+      run: |
+        VAR_FILE="vars/${{ inputs.environment }}.tfvars"
+        if [ -f "$VAR_FILE" ]; then
+          terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false -var-file="$VAR_FILE"
+        else
+          terraform -chdir=$TERRAFORM_PATH apply -auto-approve -no-color -input=false
+        fi
     - name: Reset Grafana Details
       id: delete-grafana-key
       if: ${{ always() && inputs.app-name != '' }}

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -110,17 +110,8 @@ runs:
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
-      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color
-    - name: Terraform Select Workspace
-      id: workspace
-      shell: bash
-      env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
-        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
-        OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
-      run: terraform -chdir=$TERRAFORM_PATH workspace select ${{ inputs.environment }}
+        TF_WORKSPACE: ${{ inputs.environment }}
+      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false
     - name: Terraform Plan
       id: plan
       shell: bash
@@ -130,6 +121,7 @@ runs:
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
+        TF_WORKSPACE: ${{ inputs.environment }}
       run: |
         terraform -chdir=$TERRAFORM_PATH plan -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false -out=/tmp/plan.tfplan
         echo "::set-output name=plan-file::/tmp/plan.tfplan"

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'SSH key to fetch private Terraform modules'
     required: false
     default: ''
+  tfc_token:
+    description: 'Terraform Cloud API Token'
+    required: false
+    default: ''
 outputs:
   plan-file:
     description: "Plan File"
@@ -69,6 +73,8 @@ runs:
       if: ${{ inputs.needs-python == 'true' }}
       with:
         python-version: ${{ inputs.python-version }}
+      with:
+        cli_config_credentials_token: ${{ inputs.tfc_token }}
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -111,7 +111,7 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH init -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false
+      run: terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
     - name: Terraform Plan
       id: plan
       shell: bash
@@ -123,7 +123,7 @@ runs:
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |
-        terraform -chdir=$TERRAFORM_PATH plan -var-file="vars/${{ inputs.environment }}.tfvars" -no-color -input=false -out=/tmp/plan.tfplan
+        terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan
         echo "::set-output name=plan-file::/tmp/plan.tfplan"
         terraform -chdir=$TERRAFORM_PATH show -no-color /tmp/plan.tfplan > /tmp/plan.txt
         echo "::set-output name=output-file::/tmp/plan.txt"

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -111,7 +111,13 @@ runs:
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
-      run: terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+      run: |
+        VAR_FILE="vars/${{ inputs.environment }}.tfvars"
+        if [ -f "$VAR_FILE" ]; then
+          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false -var-file="$VAR_FILE" 
+        else
+          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+        fi
     - name: Terraform Plan
       id: plan
       shell: bash
@@ -123,7 +129,12 @@ runs:
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |
-        terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan
+        VAR_FILE="vars/${{ inputs.environment }}.tfvars"
+        if [ -f "$VAR_FILE" ]; then
+          terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan -var-file="vars/${{ inputs.environment }}.tfvars"
+        else
+          terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan
+        fi
         echo "::set-output name=plan-file::/tmp/plan.tfplan"
         terraform -chdir=$TERRAFORM_PATH show -no-color /tmp/plan.tfplan > /tmp/plan.txt
         echo "::set-output name=output-file::/tmp/plan.txt"

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -105,7 +105,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.terraform-path }}
       run: |
-        echo 'grafana_auth="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"' >> "${{ inputs.environment }}.auto.tfvars"
+        # Mask the sensitive key output
+        grafana_auth_key="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"
+        echo "::add-mask::$grafana_auth_key"
+        
+        # Append the key to the .auto.tfvars file
+        echo "grafana_auth=\"$grafana_auth_key\"" >> "${{ inputs.environment }}.auto.tfvars"
     - name: Terraform Init
       id: init
       shell: bash

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -73,7 +73,6 @@ runs:
       if: ${{ inputs.needs-python == 'true' }}
       with:
         python-version: ${{ inputs.python-version }}
-      with:
         cli_config_credentials_token: ${{ inputs.tfc_token }}
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -101,40 +101,43 @@ runs:
       uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ inputs.ssh-key }}
+    - name: Configure Terraform Variables
+      shell: bash
+      working-directory: ${{ inputs.terraform-path }}
+      run: |
+        echo 'grafana_auth="${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}"' >> "${{ inputs.environment }}.auto.tfvars"
     - name: Terraform Init
       id: init
       shell: bash
+      working-directory: ${{ inputs.terraform-path }}
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TF_VAR_grafana_auth: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
+        TF_INPUT: 0
       run: |
         VAR_FILE="vars/${{ inputs.environment }}.tfvars"
         if [ -f "$VAR_FILE" ]; then
-          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false -var-file="$VAR_FILE" 
+          terraform init -no-color -var-file="$VAR_FILE" 
         else
-          terraform -chdir=$TERRAFORM_PATH init -no-color -input=false
+          terraform init -no-color
         fi
     - name: Terraform Plan
       id: plan
       shell: bash
+      working-directory: ${{ inputs.terraform-path }}
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
-        TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
-        TF_VAR_grafana_auth: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
-        TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
+        TF_INPUT: 0
       run: |
         VAR_FILE="vars/${{ inputs.environment }}.tfvars"
         if [ -f "$VAR_FILE" ]; then
-          terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan -var-file="vars/${{ inputs.environment }}.tfvars"
+          terraform plan -no-color -out=/tmp/plan.tfplan -var-file="vars/${{ inputs.environment }}.tfvars"
         else
-          terraform -chdir=$TERRAFORM_PATH plan -no-color -input=false -out=/tmp/plan.tfplan
+          terraform plan -no-color -out=/tmp/plan.tfplan
         fi
         echo "::set-output name=plan-file::/tmp/plan.tfplan"
-        terraform -chdir=$TERRAFORM_PATH show -no-color /tmp/plan.tfplan > /tmp/plan.txt
+        terraform show -no-color /tmp/plan.tfplan > /tmp/plan.txt
         echo "::set-output name=output-file::/tmp/plan.txt"

--- a/actions/plan-terraform/action.yml
+++ b/actions/plan-terraform/action.yml
@@ -105,10 +105,10 @@ runs:
       id: init
       shell: bash
       env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
+        TF_VAR_grafana_auth: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |
@@ -122,10 +122,10 @@ runs:
       id: plan
       shell: bash
       env:
-        GRAFANA_AUTH: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-key }}
         OP_CONNECT_TOKEN: ${{ inputs.onepassword-api-key }}
         TF_VAR_grafana_endpoint: ${{ inputs.grafana-endpoint != '' && inputs.grafana-endpoint || steps.get-grafana-key.outputs.endpoint }}
+        TF_VAR_grafana_auth: ${{ inputs.grafana-api-key != '' && inputs.grafana-api-key || steps.get-grafana-key.outputs.key }}
         TERRAFORM_PATH: ${{ inputs.terraform-path }}
         TF_WORKSPACE: ${{ inputs.environment }}
       run: |


### PR DESCRIPTION
# Description

This PR fixes the following action issue for the terraform `plan` and `apply` workflows:

* Terraform Cloud token should be passed as `cli_config_credentials_token` according to the [TFC documentation](https://github.com/marketplace/actions/hashicorp-setup-terraform#usage).
* TF variables can be passed [only as `*.auto.tfvars` when using the remote backend](https://developer.hashicorp.com/terraform/language/values/variables). Fixing passing of grafana key in the proper way.
* Fixing selecting of the workspace before the `init` by passing the `TF_WORKSPACE` environment variable.
* Disabling any input requests by passing the `TF_INPUT: 0` environment variable.
* Making use of the `-var-file` optional for cases where it does not exist.

## Testing

* Tested by [using the branch in `data-lake-api` repo](https://github.com/WalletConnect/data-lake-api/blob/e6ce6c355fa8fc1e01d0f39a9d8e7a2554159548/.github/workflows/ci.yaml#L148). The CI/CD deployment succeded.

## Mergin policy 🚧

The following PRs **MUST** be merged first:

* [x] https://github.com/WalletConnect/infra/pull/109
* [x] https://github.com/WalletConnect/cloud-auth-api/pull/24
* [x] https://github.com/WalletConnect/irn-node/pull/48
* [x] https://github.com/WalletConnect/rs-relay/pull/1547

## Follow-up tasks

* [ ] Stick to the new tagged version of the `WalletConnect/actions` instead of `fix/tfc_cli_credentials` branch in [data-lake-api](https://github.com/WalletConnect/data-lake-api)