### PR TITLE
fix: using `inputs.token` for auto commit

### DIFF
--- a/github/update-rust-version/action.yml
+++ b/github/update-rust-version/action.yml
@@ -35,6 +35,10 @@ runs:
         mv /tmp/cargo.toml ./Cargo.toml
         mv /tmp/cargo.lock ./Cargo.lock
 
+    - name: Set GITHUB_TOKEN for Commit
+      run: echo "GITHUB_TOKEN=${{ inputs.token }}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Commit version bump
       uses: stefanzweifel/git-auto-commit-action@v5
       with:


### PR DESCRIPTION
## Description

This PR adds changes to the `git-auto-commit-action` step to use the `inputs.token` wich is the PAT token for the auto commit. This should fix the issue where the private submodule token is used from the previous checkout step since the checkout token is used by default from the `git-auto-commit-action` action.
By this PR changes we are overriding the `GITHUB_TOKEN` from the private submodule to the PAT token and fixing the permission error.

## Testing

Tested by running [the action from this branch](https://github.com/reown-com/blockchain-api/actions/runs/11223598868/job/31199576441).