### PR TITLE
fix: bumping version of the `aws-actions/amazon-ecs-deploy-task-definition` workflow

### DIFF
--- a/actions/deploy-ecs/action.yml
+++ b/actions/deploy-ecs/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Deploy to Amazon ECS
       id: deploy
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ${{ steps.service-name.outputs.service }}

--- a/aws/ecs/deploy-image/action.yml
+++ b/aws/ecs/deploy-image/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - name: Deploy to Amazon ECS
       id: deploy
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ${{ steps.service-name.outputs.service }}


### PR DESCRIPTION
## Description

This PR increases the version of the [aws-actions/amazon-ecs-deploy-task-definition](https://github.com/aws-actions/amazon-ecs-deploy-task-definition) to the latest `@2` according to the workflow documentation to fix the `Failed to register task definition in ECS: Unexpected key 'enableFaultInjection' found in params` error when using `@1`.

## How it was tested

It was tested by running the deploy CD workflow from the branch in the [blockchain-api manual action run](https://github.com/reown-com/blockchain-api/actions/runs/12673381980).