### PR TITLE
fix: improve Claude Auto Review to validate other tools' comments

### DIFF
--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -35,10 +35,12 @@ runs:
           PROMPT="Review this pull request with focus on code quality, security, and best practices.
 
         **IMPORTANT: For PR synchronize events (subsequent pushes), be incremental:**
-        1. First, check existing review comments in this PR thread
-        2. Only flag **new** issues in the latest commits that haven't been mentioned before
-        3. Note if any previously flagged issues have been resolved
-        4. Avoid repeating feedback already given in previous reviews
+        1. First, examine all existing review comments in this PR thread for context
+        2. For each issue mentioned in previous comments (from any tool), **validate if it still exists** in the current code state
+        3. **Only report previously mentioned issues if you can confirm they still exist** by examining the actual current code
+        4. Clearly note when previously flagged issues have been resolved since the last review
+        5. Flag any genuinely **new** issues found in the latest commits
+        6. When referencing issues originally identified by other tools (GitHub Copilot, Cursor, etc.), explicitly validate their current relevance and state \"Confirmed still present\" or \"Resolved since previous review\"
 
         **For initial PR reviews or if no previous comments exist, provide a full review.**
 


### PR DESCRIPTION
## Summary
• Prevents Claude from parroting issues from other tools without validation
• Adds requirement to verify previously mentioned issues still exist in current code
• Improves incremental review logic to distinguish between resolved and persistent issues

## Problem
Claude Auto Review was ingesting PR comments from GitHub Copilot, Cursor Bugbot, and other tools, then repeating their feedback even when issues were already fixed in subsequent commits.

## Solution
Enhanced the incremental review prompt to:
- Validate each previously mentioned issue against current code state
- Only report issues confirmed to still exist
- Explicitly track resolution status of flagged issues
- Require evidence-based reporting before mentioning any issue

## Test plan
- [ ] Test incremental reviews on PRs with comments from multiple tools
- [ ] Verify Claude validates issue relevance instead of parroting
- [ ] Confirm resolved issues are properly noted as resolved

🤖 Generated with [Claude Code](https://claude.ai/code)