### PR TITLE
feat: add reusable CTA assistant GitHub action

### DIFF
--- a/github/cta-assistant/README.md
+++ b/github/cta-assistant/README.md
@@ -1,0 +1,128 @@
+# CTA Assistant Action
+
+A reusable GitHub Action for managing Copyright Transfer Agreement (CTA) signatures from contributors.
+
+## Overview
+
+This action automates the process of collecting CTA signatures from contributors to your repository. It integrates with pull requests to ensure all contributors have signed your CTA before their contributions can be merged.
+
+## Features
+
+- Automated CTA signature collection
+- Configurable CTA document URL
+- Customizable signature storage location
+- Flexible commit messages and PR comments
+- Support for remote signature storage
+- Automatic pull request status updates
+
+## Usage
+
+### Basic Setup
+
+1. Create a workflow file in your repository (e.g., `.github/workflows/cta.yml`):
+
+```yaml
+name: "CTA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Required permissions
+permissions:
+  actions: write
+  contents: write # can be 'read' if signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CTA:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: walletconnect/actions/github/cta-assistant@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Required only for remote signature storage:
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+```
+
+### Advanced Configuration
+
+```yaml
+steps:
+  - uses: walletconnect/actions/github/cta-assistant@v1
+    with:
+      cta-document-url: 'https://your-domain.com/cta-document'
+      signatures-path: 'legal/signatures/cta.json'
+      signatures-branch: 'cta-signatures'
+      create-file-commit-message: 'docs: initialize CTA signatures file'
+      signed-commit-message: 'docs: @$contributorName signed the CTA'
+      custom-pr-sign-comment: 'I have read and agree to the CTA terms'
+      custom-allsigned-prcomment: 'All contributors have signed the CTA! 🎉'
+      remote-organization-name: 'your-org'
+      remote-repository-name: 'cta-signatures'
+      lock-pullrequest-aftermerge: 'false'
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `cta-document-url` | URL to the CTA document | No | `https://gist.github.com/bkrem/a4233ab5e431d485e9836db072fda44c` |
+| `signatures-path` | Path to store signatures | No | `signatures/version1/cta.json` |
+| `signatures-branch` | Branch for signatures (should not be protected) | No | `signatures` |
+| `create-file-commit-message` | Commit message when creating signatures file | No | `Creating file for storing CTA Signatures` |
+| `signed-commit-message` | Commit message when contributor signs | No | `@$contributorName has signed the CTA` |
+| `custom-pr-sign-comment` | Comment contributors use to sign | No | `I have read the CTA Document and I hereby sign the CTA` |
+| `custom-allsigned-prcomment` | Comment when all have signed | No | `All contributors have signed the CTA ✍️ ✅` |
+| `custom-notsigned-prcomment` | Custom message for unsigned contributors | No | Auto-generated |
+| `remote-organization-name` | Remote org for signature storage | No | - |
+| `remote-repository-name` | Remote repo for signature storage | No | - |
+| `lock-pullrequest-aftermerge` | Lock PR after merge | No | `true` |
+
+## How It Works
+
+1. When a pull request is opened, the action checks if all contributors have signed the CTA
+2. If not signed, a comment is posted with instructions and a link to the CTA document  
+3. Contributors sign by posting the specified comment text in the PR
+4. Once all contributors have signed, the PR is marked as compliant
+5. Signatures are stored in the specified branch and path
+
+## Required Permissions
+
+The workflow requires these permissions:
+- `actions: write` - Update workflow status
+- `contents: write` - Commit signature files (or `read` if using remote storage)
+- `pull-requests: write` - Comment on PRs
+- `statuses: write` - Update PR status checks
+
+## Remote Storage
+
+For organizations managing multiple repositories, you can store signatures in a centralized location:
+
+1. Create a dedicated repository for signatures
+2. Generate a Personal Access Token with `repo` scope
+3. Add it as `PERSONAL_ACCESS_TOKEN` secret
+4. Configure `remote-organization-name` and `remote-repository-name`
+
+## Environment Variables
+
+- `GITHUB_TOKEN` - Required (automatically provided)
+- `PERSONAL_ACCESS_TOKEN` - Required only for remote signature storage
+
+## Troubleshooting
+
+### Contributors Can't Sign
+- Ensure the comment text matches `custom-pr-sign-comment` exactly
+- Check that the workflow has proper permissions
+- Verify the signatures branch exists and is not protected
+
+### Signatures Not Persisting  
+- Check write permissions to the repository
+- Ensure the signatures branch is not protected
+- Verify `PERSONAL_ACCESS_TOKEN` if using remote storage
+
+### Status Not Updating
+- Confirm `statuses: write` permission is granted
+- Check that the workflow triggers on the correct events

--- a/github/cta-assistant/action.yml
+++ b/github/cta-assistant/action.yml
@@ -1,0 +1,68 @@
+name: "CTA Assistant"
+description: "Automated Copyright Transfer Agreement (CTA) assistant for managing contributor signatures"
+author: "WalletConnect"
+
+inputs:
+  cta-document-url:
+    description: "URL to the CTA document that contributors must read and sign"
+    required: false
+    default: 'https://gist.github.com/bkrem/a4233ab5e431d485e9836db072fda44c'
+  signatures-path:
+    description: "Path to store the CTA signatures file"
+    required: false
+    default: 'signatures/version1/cta.json'
+  signatures-branch:
+    description: "Branch to store the CTA signatures (should not be protected)"
+    required: false
+    default: 'signatures'
+  create-file-commit-message:
+    description: "Commit message when creating the signatures file"
+    required: false
+    default: 'Creating file for storing CTA Signatures'
+  signed-commit-message:
+    description: "Commit message when a contributor signs the CTA"
+    required: false
+    default: '@$contributorName has signed the CTA'
+  custom-pr-sign-comment:
+    description: "Comment that contributors must use to sign the CTA"
+    required: false
+    default: 'I have read the CTA Document and I hereby sign the CTA'
+  custom-allsigned-prcomment:
+    description: "Comment posted when all contributors have signed the CTA"
+    required: false
+    default: 'All contributors have signed the CTA ✍️ ✅'
+  custom-notsigned-prcomment:
+    description: "Custom message for contributors who haven't signed the CTA"
+    required: false
+    default: ""
+  remote-organization-name:
+    description: "Remote organization name for storing signatures (optional)"
+    required: false
+  remote-repository-name:
+    description: "Remote repository name for storing signatures (optional)"
+    required: false
+  lock-pullrequest-aftermerge:
+    description: "Lock pull request after merging"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "CTA Assistant"
+      if: (github.event.comment.body == 'recheck' || github.event.comment.body == inputs.custom-pr-sign-comment) || github.event_name == 'pull_request_target'
+      uses: contributor-assistant/github-action@v2.6.1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        path-to-signatures: ${{ inputs.signatures-path }}
+        path-to-document: ${{ inputs.cta-document-url }}
+        branch: ${{ inputs.signatures-branch }}
+        create-file-commit-message: ${{ inputs.create-file-commit-message }}
+        signed-commit-message: ${{ inputs.signed-commit-message }}
+        custom-notsigned-prcomment: ${{ inputs.custom-notsigned-prcomment || format('Thank you for your contribution! We ask that you please read and sign our [CTA Document]({0}) before we can accept your contribution. You can sign the CTA simply by posting a Pull Request Comment with the following text:', inputs.cta-document-url) }}
+        custom-pr-sign-comment: ${{ inputs.custom-pr-sign-comment }}
+        custom-allsigned-prcomment: ${{ inputs.custom-allsigned-prcomment }}
+        remote-organization-name: ${{ inputs.remote-organization-name }}
+        remote-repository-name: ${{ inputs.remote-repository-name }}
+        lock-pullrequest-aftermerge: ${{ inputs.lock-pullrequest-aftermerge }}


### PR DESCRIPTION
## Summary
- Converted existing CLA workflow to reusable composite action
- Updated all terminology from CLA to CTA (Copyright Transfer Agreement) 
- Maintained full backward compatibility with all configuration options
- Added comprehensive documentation and usage examples

## Key Features
- **Reusable composite action** - Can be used across multiple repositories
- **Configurable CTA document URL** - Point to your organization's CTA
- **Flexible signature storage** - Local or remote repository options
- **Customizable messaging** - All PR comments and commit messages configurable
- **Full permission control** - Explicit permission requirements documented

## Usage Example
```yaml
name: "CTA Assistant"
on:
  issue_comment:
    types: [created]
  pull_request_target:
    types: [opened, closed, synchronize]

permissions:
  actions: write
  contents: write
  pull-requests: write
  statuses: write

jobs:
  CTA:
    runs-on: ubuntu-latest
    steps:
      - uses: walletconnect/actions/github/cta-assistant@v1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Test plan
- [ ] Test basic CTA workflow with default settings
- [ ] Test custom CTA document URL configuration
- [ ] Test remote signature storage functionality
- [ ] Verify all permission requirements work correctly
- [ ] Test contributor signing flow end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)