### PR TITLE
feat: add external domain URL detection to auto-review action

### DIFF
--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -53,7 +53,16 @@ runs:
         - **Documentation updates** if needed for significant changes
         - **Type safety** and proper usage of type systems
         - **Error handling** and edge cases
-        - **Code maintainability** and readability"
+        - **Code maintainability** and readability
+
+        **EXTERNAL DOMAIN URL DETECTION:**
+        Scan all changed files for URLs matching the pattern 'https?://(?:www\.)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})'. If any URLs are found pointing to domains other than the approved company domains (reown.com, walletconnect.com, walletconnect.org), report them using this exact format:
+
+        🔒 **External Domain URL Detected** (Non-blocking)
+        **URL:** [detected_url]
+        **File:** [file_path:line_number]
+
+        This change introduces URLs pointing to external domains. Please verify that these external dependencies are intentional and review for potential security, privacy, or compliance implications. Approved company domains are: reown.com, walletconnect.com, walletconnect.org"
 
 
           # Add project context


### PR DESCRIPTION
## Context

- Action item from: https://www.notion.so/walletconnect/COE-Secure-site-fonts-loaded-from-personal-cloudinary-account-2793a661771e8027b4ceffae31dbb309#2793a661771e8027b4ceffae31dbb309

## Summary
- Added external domain URL detection capability to the Claude auto-review action
- Scans changed files for URLs pointing to domains outside approved company domains
- Reports findings as non-blocking security review items

## Changes
- Extended the review prompt in `action.yml` to include URL pattern matching
- Added detection for URLs matching pattern `https?://(?:www\.)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})`
- Whitelisted approved domains: `reown.com`, `walletconnect.com`, `walletconnect.org`
- Configured non-blocking bug reports with security review guidance

## Test plan
- [ ] Test with PR containing external URLs (should flag them)
- [ ] Test with PR containing only approved domain URLs (should not flag)
- [ ] Verify the output format matches specification
- [ ] Confirm existing review functionality remains unaffected