### PR TITLE
chore: update Claude model to Sonnet 4.5

### DIFF
--- a/claude/auto-review/README.md
+++ b/claude/auto-review/README.md
@@ -62,13 +62,13 @@ jobs:
 
 ### Inputs
 
-| Input               | Required | Default                    | Description                                                                  |
-| ------------------- | -------- | -------------------------- | ---------------------------------------------------------------------------- |
-| `anthropic_api_key` | ✅       | -                          | Your Anthropic API key for Claude access                                     |
-| `model`             | ❌       | `claude-sonnet-4-20250514` | Claude model to use for reviews                                              |
-| `timeout_minutes`   | ❌       | `60`                       | Timeout in minutes for the review process                                    |
-| `custom_prompt`     | ❌       | -                          | Complete custom prompt override. Ignores all other prompt inputs if provided |
-| `project_context`   | ❌       | -                          | Additional project-specific context to help Claude understand your codebase  |
+| Input               | Required | Default                      | Description                                                                  |
+| ------------------- | -------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| `anthropic_api_key` | ✅       | -                            | Your Anthropic API key for Claude access                                     |
+| `model`             | ❌       | `claude-sonnet-4-5-20250929` | Claude model to use for reviews                                              |
+| `timeout_minutes`   | ❌       | `60`                         | Timeout in minutes for the review process                                    |
+| `custom_prompt`     | ❌       | -                            | Complete custom prompt override. Ignores all other prompt inputs if provided |
+| `project_context`   | ❌       | -                            | Additional project-specific context to help Claude understand your codebase  |
 
 ## Usage Examples
 
@@ -108,7 +108,7 @@ jobs:
   uses: WalletConnect/actions/claude/auto-review@master
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-5-20250929
     timeout_minutes: "90"
 ```
 

--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -9,7 +9,7 @@ inputs:
   model:
     description: "Claude model to use for reviews"
     required: false
-    default: "claude-sonnet-4-20250514"
+    default: "claude-sonnet-4-5-20250929"
   timeout_minutes:
     description: "Timeout in minutes for the review process"
     required: false


### PR DESCRIPTION
## Summary
- Updates the default Claude model from `claude-sonnet-4-20250514` to `claude-sonnet-4-5-20250929`
- Updates README.md documentation to reflect the new default model version

## Changes
- `claude/auto-review/action.yml`: Updated default model parameter
- `claude/auto-review/README.md`: Updated documentation table and example to show new model version

## Test plan
- [ ] Verify action still functions with the new model
- [ ] Documentation reflects correct default values