### PR TITLE
feat(auto-review): add data classification policy sub-agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Wraps `anthropics/claude-code-action` to provide automated PR reviews. Key compo
 Specialized review tasks run as conditional subagents to keep the main review context focused:
 
 - **License Compliance** (`agents/review-license-compliance.md`) — spawned when dependency manifest/lockfiles change. Heuristic: `scripts/should-spawn-license-compliance.js`. Findings use `lic-` prefixed IDs.
+- **Data Classification** (`agents/review-data-classification.md`) — spawned when infrastructure, secret/env files, DB schemas, or API routes change, or when patches contain sensitive data keywords. Heuristic: `scripts/should-spawn-data-classification.js`. Findings use `dcl-` prefixed IDs.
 
 ### Workflows
 

--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Force license compliance agent regardless of heuristic"
     required: false
     default: "false"
+  force_data_classification_agent:
+    description: "Force data classification agent regardless of heuristic"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -68,6 +72,23 @@ runs:
         echo "SPAWN_LICENSE_COMPLIANCE=$SPAWN" >> $GITHUB_ENV
         echo "LICENSE_COMPLIANCE_REASON=$REASON" >> $GITHUB_ENV
         echo "License compliance agent: spawn=$SPAWN reason=\"$REASON\""
+
+    - name: Determine if data classification agent should spawn
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        FORCE_DATA_CLASSIFICATION_AGENT: ${{ inputs.force_data_classification_agent }}
+      run: |
+        SCRIPT_PATH="${{ github.action_path }}/scripts/should-spawn-data-classification.js"
+        RESULT=$(node "$SCRIPT_PATH")
+        SPAWN=$(echo "$RESULT" | jq -r '.spawn')
+        REASON=$(echo "$RESULT" | jq -r '.reason')
+        echo "SPAWN_DATA_CLASSIFICATION=$SPAWN" >> $GITHUB_ENV
+        echo "DATA_CLASSIFICATION_REASON=$REASON" >> $GITHUB_ENV
+        echo "Data classification agent: spawn=$SPAWN reason=\"$REASON\""
 
     - name: Set up review prompt
       shell: bash
@@ -202,6 +223,30 @@ runs:
         After the agent completes, merge its findings into your consolidated output.
         - Use the agent's brk- prefixed IDs as-is
         - Deduplicate if you found the same issue independently (prefer brk- prefixed ID)
+        - Sort all findings by severity: CRITICAL > HIGH > MEDIUM > LOW"
+          fi
+
+          # Conditionally add data classification subagent instructions
+          if [[ "$SPAWN_DATA_CLASSIFICATION" == "true" ]]; then
+            PROMPT="$PROMPT
+
+        ---
+
+        ## DATA CLASSIFICATION SUBAGENT
+
+        Based on PR analysis: ${DATA_CLASSIFICATION_REASON}
+
+        Spawn ONE specialized subagent to check data classification policy compliance.
+
+        ### Instructions:
+        Use the Task tool with subagent_type=\"general-purpose\" to launch the agent. In the prompt include:
+        1. \"Read your spec file at ${{ github.action_path }}/agents/review-data-classification.md and follow its instructions.\"
+        2. PR number: ${{ github.event.pull_request.number }}, Repository: ${{ github.repository }}
+        3. The list of changed files in this PR
+
+        After the agent completes, merge its findings into your consolidated output.
+        - Use the agent's dcl- prefixed IDs as-is
+        - Deduplicate if you found the same issue independently (prefer dcl- prefixed ID)
         - Sort all findings by severity: CRITICAL > HIGH > MEDIUM > LOW"
           fi
 

--- a/claude/auto-review/agents/review-data-classification.md
+++ b/claude/auto-review/agents/review-data-classification.md
@@ -1,0 +1,111 @@
+# Data Classification Policy Review Agent
+
+You are a specialized reviewer that enforces Reown's Data Classification and Management Policy (SOC 1 Type II compliant). Your job is to identify violations of data handling requirements across four classification tiers: Critical, Confidential, Internal, and Public.
+
+## Classification Tiers
+
+### Critical Data
+Secrets, API keys, private keys, credentials, encryption keys. Require the highest level of protection — never in source code, always encrypted, access strictly controlled.
+
+### Confidential Data
+PII (emails, phone numbers, SSNs, dates of birth), financial data, authentication tokens. Require encryption at rest and in transit, access controls, and audit logging.
+
+### Internal Data
+Internal service configurations, non-public API endpoints, internal documentation, cache data. Require network isolation and basic access controls.
+
+### Public Data
+Published documentation, public API specs, marketing content. No special handling required.
+
+## Focus Areas
+
+### 1. Critical Data Handling
+- Hardcoded secrets, API keys, or credentials in source code
+- Plaintext credential storage (config files, environment defaults)
+- Private keys committed to source control
+- Secrets in non-secret-managed locations (plain env vars without vault/KMS)
+- Non-constant-time comparison of secrets or tokens
+
+### 2. Confidential Data Handling
+- PII logged or exposed in responses/errors
+- Unencrypted PII storage (database columns, files)
+- Missing access controls on endpoints returning confidential data
+- PII passed in URL query parameters (logged by proxies/CDNs)
+- User data returned without field-level filtering
+
+### 3. Data in Transit
+- HTTP instead of HTTPS for any data transfer
+- Missing TLS configuration in service definitions
+- Insecure WebSocket connections (ws:// instead of wss://)
+- Missing certificate validation or pinning where required
+- Unencrypted inter-service communication
+
+### 4. Data in Use
+- Secrets or PII in log statements (`console.log`, `logger.*`, `log.*`)
+- Sensitive data in error messages returned to clients
+- Credentials in debug/trace output
+- PII in client-side analytics or telemetry payloads
+
+### 5. Infrastructure Compliance
+- Unencrypted storage in Terraform/IaC (S3 buckets, RDS, EBS without encryption)
+- Missing KMS key configuration for encrypted resources
+- Public network exposure of internal data stores (security groups, NACLs)
+- Missing audit logging configuration (CloudTrail, access logs)
+- Missing backup or replication configuration for critical data stores
+- Database instances without encryption at rest enabled
+
+### 6. Data Retention
+- Missing TTL/expiry on ephemeral data (sessions, temporary tokens, caches)
+- Missing deletion protection on critical data stores
+- No retention policy defined for logs containing sensitive data
+- Indefinite storage of PII without documented justification
+
+## False-Positive Guardrails
+
+**CRITICAL: Minimize false positives. Follow these rules strictly:**
+
+- **Read full file context**, not just the diff. Code that looks like a violation in isolation may have proper handling elsewhere.
+- **Don't flag test fixtures or mock data**: Test files using fake credentials, dummy PII, or mock tokens are expected.
+- **Don't flag documentation examples**: Example code in docs showing placeholder secrets (`YOUR_API_KEY`, `xxx`, `example-token`) is not a violation.
+- **Don't flag environment variable references**: Reading from `process.env.SECRET_KEY` is correct — the violation is hardcoding the value.
+- **Don't flag secret manager integrations**: Code that reads from Vault, AWS Secrets Manager, KMS, or similar is compliant.
+- **Check for encryption wrappers**: A field named `password` stored via `bcrypt.hash()` or similar is properly handled.
+- **Variable names alone are not violations**: A variable named `secret` or `token` that contains non-sensitive data (e.g., a CSRF token name) is fine — check what it actually contains.
+
+## Severity Mapping
+
+- **CRITICAL**: Violations involving Critical-tier data (exposed secrets, plaintext keys, hardcoded credentials)
+- **HIGH**: Violations involving Confidential-tier data (PII exposure, missing encryption, unprotected endpoints)
+- **MEDIUM**: Violations involving Internal-tier data (unencrypted caches, missing network isolation)
+- **LOW**: Best-practice gaps (missing audit logging, incomplete retention config, missing deletion protection)
+
+## Output Format
+
+Use the same `#### Issue N:` format as the main review. **All IDs MUST use the `dcl-` prefix.**
+
+```
+#### Issue N: Brief description of the data classification violation
+**ID:** dcl-{file-slug}-{semantic-slug}-{hash}
+**File:** path/to/file.ext:line
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW
+**Category:** data_classification
+
+**Context:**
+- **Pattern:** What data handling violation was detected
+- **Risk:** Why this violates the data classification policy
+- **Impact:** Potential consequences (data breach, compliance failure, audit finding)
+- **Trigger:** When this becomes exploitable or discovered
+
+**Recommendation:** How to fix (encrypt, mask, use secret manager, add access controls, etc.)
+```
+
+**ID Generation:** `dcl-{filename}-{2-4-key-terms}-{SHA256(path+desc).substr(0,4)}`
+Examples:
+- `dcl-config-hardcoded-api-key-a3f1`
+- `dcl-users-pii-in-logs-b2c4`
+- `dcl-main-unencrypted-s3-e7d2`
+
+## If No Data Classification Issues Found
+
+If you find no data classification issues after thorough analysis, respond with exactly:
+
+"No data classification issues found."

--- a/claude/auto-review/scripts/__tests__/should-spawn-data-classification.test.js
+++ b/claude/auto-review/scripts/__tests__/should-spawn-data-classification.test.js
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shouldSpawnDataClassification, fetchPrFiles, fetchPrLabels } from '../should-spawn-data-classification.js';
+import { ghApi } from '../lib/github-utils.js';
+
+vi.mock('../lib/github-utils.js', async () => {
+  const actual = await vi.importActual('../lib/github-utils.js');
+  return {
+    ...actual,
+    ghApi: vi.fn(),
+  };
+});
+
+describe('shouldSpawnDataClassification', () => {
+  // ---- File pattern triggers ------------------------------------------------
+
+  it('should spawn for Terraform files (.tf)', () => {
+    const files = [{ filename: 'infra/main.tf', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Terraform/IaC');
+  });
+
+  it('should spawn for Terraform var files (.tfvars)', () => {
+    const files = [{ filename: 'infra/vars/prod.tfvars', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Terraform/IaC');
+  });
+
+  it('should spawn for Kubernetes YAML files', () => {
+    const files = [{ filename: 'k8s/deployment.yaml', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Kubernetes/Helm');
+  });
+
+  it('should spawn for Helm chart files', () => {
+    const files = [{ filename: 'helm/charts/values.yml', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Kubernetes/Helm');
+  });
+
+  it('should not spawn for generic YAML files outside k8s/helm paths', () => {
+    const files = [{ filename: 'src/config.yml', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toContain('No data classification signals');
+  });
+
+  it('should spawn for CloudFormation templates', () => {
+    const files = [{ filename: 'infra/cloudformation-stack.json', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('CloudFormation');
+  });
+
+  it('should spawn for .env files', () => {
+    const files = [{ filename: '.env', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('environment/secret');
+  });
+
+  it('should spawn for .env.local files', () => {
+    const files = [{ filename: '.env.local', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('environment/secret');
+  });
+
+  it('should spawn for files with secret in the name', () => {
+    const files = [{ filename: 'config/secrets.json', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('environment/secret');
+  });
+
+  it('should spawn for files with credential in the name', () => {
+    const files = [{ filename: 'config/credentials.yml', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('environment/secret');
+  });
+
+  it('should spawn for migration files', () => {
+    const files = [{ filename: 'db/migrations/001_create_users.sql', status: 'added' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('database/schema');
+  });
+
+  it('should spawn for schema files', () => {
+    const files = [{ filename: 'src/db/schema.prisma', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('database/schema');
+  });
+
+  it('should spawn for model files', () => {
+    const files = [{ filename: 'src/models/user.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('database/schema');
+  });
+
+  it('should spawn for API route files', () => {
+    const files = [{ filename: 'src/api/users.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('API route/handler');
+  });
+
+  it('should spawn for controller files', () => {
+    const files = [{ filename: 'src/users.controller.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('API route/handler');
+  });
+
+  it('should spawn for handler files', () => {
+    const files = [{ filename: 'src/handlers.js', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('API route/handler');
+  });
+
+  it('should spawn for middleware files', () => {
+    const files = [{ filename: 'src/middleware.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('API route/handler');
+  });
+
+  // ---- Keyword-based triggers -----------------------------------------------
+
+  it('should spawn when patch contains password keyword', () => {
+    const files = [{ filename: 'src/auth.ts', status: 'modified', patch: '+  const password = req.body.password;' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains api_key keyword', () => {
+    const files = [{ filename: 'src/config.ts', status: 'modified', patch: '+  api_key: "sk-12345"' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains encrypt keyword', () => {
+    const files = [{ filename: 'src/crypto.ts', status: 'modified', patch: '+  const encrypted = encrypt(data);' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains PII keyword (email)', () => {
+    const files = [{ filename: 'src/user.ts', status: 'modified', patch: '+  const email = user.email;' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains console.log', () => {
+    const files = [{ filename: 'src/debug.ts', status: 'modified', patch: '+  console.log(data);' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains KMS keyword', () => {
+    const files = [{ filename: 'src/storage.ts', status: 'modified', patch: '+  kmsKeyId: process.env.KMS_KEY_ID' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains token keyword', () => {
+    const files = [{ filename: 'src/auth.ts', status: 'modified', patch: '+  const token = generateToken();' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  it('should spawn when patch contains gdpr keyword', () => {
+    const files = [{ filename: 'src/privacy.ts', status: 'modified', patch: '+  // GDPR compliance' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  // ---- Non-matching files ---------------------------------------------------
+
+  it('should not spawn for non-matching files without keywords', () => {
+    const files = [{ filename: 'src/utils.ts', status: 'modified', patch: '+  return x + y;' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toContain('No data classification signals');
+  });
+
+  // ---- Empty / null / undefined files ---------------------------------------
+
+  it('should not spawn for empty files array', () => {
+    const result = shouldSpawnDataClassification([]);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toBe('No files in PR');
+  });
+
+  it('should not spawn for null files', () => {
+    const result = shouldSpawnDataClassification(null);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toBe('No files in PR');
+  });
+
+  it('should not spawn for undefined files', () => {
+    const result = shouldSpawnDataClassification(undefined);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toBe('No files in PR');
+  });
+
+  // ---- skip-review label ----------------------------------------------------
+
+  it('should not spawn when skip-review label is present', () => {
+    const files = [{ filename: 'infra/main.tf', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files, { labels: ['skip-review'] });
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toBe('skip-review label present');
+  });
+
+  it('should not spawn when skip-review label is among multiple labels', () => {
+    const files = [{ filename: 'infra/main.tf', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files, { labels: ['enhancement', 'skip-review', 'urgent'] });
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toBe('skip-review label present');
+  });
+
+  // ---- Force flag -----------------------------------------------------------
+
+  it('should spawn when force flag is set even with no matching files', () => {
+    const files = [{ filename: 'README.md', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files, { force: true });
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('forced');
+  });
+
+  it('should spawn when force flag is set even with skip-review label', () => {
+    const files = [{ filename: 'src/app.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files, { labels: ['skip-review'], force: true });
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('forced');
+  });
+
+  // ---- Docs-only and test-only exclusions -----------------------------------
+
+  it('should not spawn for docs-only changes', () => {
+    const files = [{ filename: 'README.md', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toContain('documentation-only');
+  });
+
+  it('should not spawn for test-only changes', () => {
+    const files = [{ filename: 'src/__tests__/auth.test.ts', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(false);
+    expect(result.reason).toContain('test-only');
+  });
+
+  // ---- Combined reasons for multiple triggers --------------------------------
+
+  it('should combine reasons for multiple pattern triggers', () => {
+    const files = [
+      { filename: 'infra/main.tf', status: 'modified' },
+      { filename: '.env', status: 'modified' },
+      { filename: 'src/api/users.ts', status: 'modified' },
+    ];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Terraform/IaC');
+    expect(result.reason).toContain('environment/secret');
+    expect(result.reason).toContain('API route/handler');
+  });
+
+  it('should combine pattern and keyword triggers', () => {
+    const files = [
+      { filename: 'infra/main.tf', status: 'modified' },
+      { filename: 'src/config.ts', status: 'modified', patch: '+  secret: "my-secret"' },
+    ];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Terraform/IaC');
+    expect(result.reason).toContain('sensitive data keywords');
+  });
+
+  // ---- Nested paths ---------------------------------------------------------
+
+  it('should match Terraform files in subdirectories', () => {
+    const files = [{ filename: 'services/api/infra/main.tf', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Terraform/IaC');
+  });
+
+  it('should match .env files in subdirectories', () => {
+    const files = [{ filename: 'services/api/.env.production', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('environment/secret');
+  });
+
+  it('should match deploy manifests in k8s paths', () => {
+    const files = [{ filename: 'deploy/kubernetes/service.yaml', status: 'modified' }];
+    const result = shouldSpawnDataClassification(files);
+    expect(result.spawn).toBe(true);
+    expect(result.reason).toContain('Kubernetes/Helm');
+  });
+});
+
+describe('fetchPrFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call ghApi with correct endpoint', () => {
+    ghApi.mockReturnValue([{ filename: 'test.js' }]);
+    const context = { repo: { owner: 'org', repo: 'repo' }, issue: { number: 42 } };
+    const result = fetchPrFiles(context);
+    expect(ghApi).toHaveBeenCalledWith('/repos/org/repo/pulls/42/files');
+    expect(result).toEqual([{ filename: 'test.js' }]);
+  });
+
+  it('should return empty array when ghApi returns null', () => {
+    ghApi.mockReturnValue(null);
+    const context = { repo: { owner: 'org', repo: 'repo' }, issue: { number: 1 } };
+    const result = fetchPrFiles(context);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchPrLabels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call ghApi and return label names', () => {
+    ghApi.mockReturnValue([{ name: 'bug' }, { name: 'security' }]);
+    const context = { repo: { owner: 'org', repo: 'repo' }, issue: { number: 42 } };
+    const result = fetchPrLabels(context);
+    expect(ghApi).toHaveBeenCalledWith('/repos/org/repo/issues/42/labels');
+    expect(result).toEqual(['bug', 'security']);
+  });
+
+  it('should return empty array when ghApi returns null', () => {
+    ghApi.mockReturnValue(null);
+    const context = { repo: { owner: 'org', repo: 'repo' }, issue: { number: 1 } };
+    const result = fetchPrLabels(context);
+    expect(result).toEqual([]);
+  });
+});

--- a/claude/auto-review/scripts/extract-findings-from-comment.js
+++ b/claude/auto-review/scripts/extract-findings-from-comment.js
@@ -61,8 +61,9 @@ export function parseClaudeComment(commentBody) {
       const agentPrefixMap = {
         'brk': 'review-breaking-changes',
         'lic': 'review-license-compliance',
+        'dcl': 'review-data-classification',
       };
-      const agentPrefixMatch = finding.id.match(/^(brk|lic)-/);
+      const agentPrefixMatch = finding.id.match(/^(brk|lic|dcl)-/);
       if (agentPrefixMatch) {
         finding.agent = agentPrefixMap[agentPrefixMatch[1]];
       }

--- a/claude/auto-review/scripts/should-spawn-data-classification.js
+++ b/claude/auto-review/scripts/should-spawn-data-classification.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+/**
+ * Determine whether the data classification subagent should be spawned
+ * based on PR file patterns, patch content keywords, and labels.
+ *
+ * Outputs JSON: { spawn: boolean, reason: string }
+ */
+
+import { ghApi, loadGitHubContext, createLogger } from './lib/github-utils.js';
+
+const logger = createLogger('should-spawn-data-classification.js');
+
+// ---- File pattern triggers ------------------------------------------------
+
+const FILE_PATTERNS = {
+  infrastructure: /\.tf$|\.tfvars$/,
+  kubernetesHelm: /\.(ya?ml)$/i,
+  cloudformation: /cloudformation|cfn/i,
+  envSecrets: /(^|\/)\.env|secret|credential/i,
+  dbSchema: /migration|schema|model/i,
+  apiRoutes: /routes?\.[jt]sx?$|controllers?\.[jt]sx?$|handlers?\.[jt]sx?$|middleware\.[jt]sx?$|api\//i,
+};
+
+/**
+ * Check if a Kubernetes/Helm YAML is actually infra-related by path context.
+ * Generic .yml files (like CI workflows) should not trigger — only k8s/helm paths.
+ */
+function isKubernetesOrHelmYaml(filePath) {
+  return /k8s|kubernetes|helm|chart|deploy|manifests?/i.test(filePath);
+}
+
+// ---- Patch keyword triggers -----------------------------------------------
+
+const SENSITIVE_KEYWORDS = [
+  // Secrets
+  'password',
+  'secret',
+  'api_key',
+  'apiKey',
+  'private_key',
+  'privateKey',
+  'credential',
+  'token',
+  // Crypto
+  'encrypt',
+  'decrypt',
+  'kms',
+  'KMS',
+  'AES',
+  'TLS',
+  // PII
+  'email',
+  'phone',
+  'ssn',
+  'date_of_birth',
+  'dateOfBirth',
+  'personal',
+  'pii',
+  'gdpr',
+  // Logging with sensitive terms (partial — full check done in combination)
+  'console\\.log',
+  'logger\\.',
+  'log\\.',
+  'logging',
+];
+
+const KEYWORD_REGEX = new RegExp(SENSITIVE_KEYWORDS.join('|'), 'i');
+
+// ---- Skip conditions ------------------------------------------------------
+
+const DOCS_ONLY_REGEX = /\.(md|txt|rst|adoc)$/i;
+const TEST_ONLY_REGEX = /(\/__tests__\/|\.test\.|\.spec\.|test\/|tests\/|__mocks__\/)/i;
+
+// ---- Core decision function -----------------------------------------------
+
+/**
+ * Determine whether the data classification agent should be spawned.
+ *
+ * @param {Array} files - PR file objects from GitHub API (filename, status, patch)
+ * @param {Object} metadata - Additional metadata
+ * @param {string[]} [metadata.labels] - PR label names
+ * @param {boolean} [metadata.force] - Force spawn regardless of heuristic
+ * @returns {{ spawn: boolean, reason: string }}
+ */
+export function shouldSpawnDataClassification(files, metadata = {}) {
+  const { labels = [], force = false } = metadata;
+
+  // Force override — always wins
+  if (force) {
+    return { spawn: true, reason: 'forced via input' };
+  }
+
+  // Skip conditions
+  if (labels.includes('skip-review')) {
+    return { spawn: false, reason: 'skip-review label present' };
+  }
+
+  if (!files || files.length === 0) {
+    return { spawn: false, reason: 'No files in PR' };
+  }
+
+  // Check if all files are docs-only
+  const allDocs = files.every(f => DOCS_ONLY_REGEX.test(f.filename));
+  if (allDocs) {
+    return { spawn: false, reason: 'All files are documentation-only' };
+  }
+
+  // Check if all files are test-only
+  const allTests = files.every(f => TEST_ONLY_REGEX.test(f.filename));
+  if (allTests) {
+    return { spawn: false, reason: 'All files are test-only' };
+  }
+
+  // Collect trigger reasons
+  const reasons = [];
+  const patternHits = new Set();
+  let hasKeywordHits = false;
+
+  for (const file of files) {
+    const { filename, patch } = file;
+
+    if (FILE_PATTERNS.infrastructure.test(filename)) patternHits.add('Terraform/IaC files');
+    if (FILE_PATTERNS.kubernetesHelm.test(filename) && isKubernetesOrHelmYaml(filename)) {
+      patternHits.add('Kubernetes/Helm configs');
+    }
+    if (FILE_PATTERNS.cloudformation.test(filename)) patternHits.add('CloudFormation templates');
+    if (FILE_PATTERNS.envSecrets.test(filename)) patternHits.add('environment/secret files');
+    if (FILE_PATTERNS.dbSchema.test(filename)) patternHits.add('database/schema files');
+    if (FILE_PATTERNS.apiRoutes.test(filename)) patternHits.add('API route/handler files');
+
+    if (patch && KEYWORD_REGEX.test(patch)) hasKeywordHits = true;
+  }
+
+  if (patternHits.size > 0) reasons.push(...patternHits);
+  if (hasKeywordHits) reasons.push('sensitive data keywords in patch');
+
+  if (reasons.length > 0) {
+    return { spawn: true, reason: reasons.join(', ') };
+  }
+
+  return { spawn: false, reason: 'No data classification signals detected' };
+}
+
+// ---- GitHub API helpers ---------------------------------------------------
+
+/**
+ * Fetch PR files from GitHub API
+ * @param {Object} context - GitHub context
+ * @returns {Array} PR files
+ */
+export function fetchPrFiles(context) {
+  return ghApi(
+    `/repos/${context.repo.owner}/${context.repo.repo}/pulls/${context.issue.number}/files`
+  ) || [];
+}
+
+/**
+ * Fetch PR labels from GitHub API
+ * @param {Object} context - GitHub context
+ * @returns {string[]} Label names
+ */
+export function fetchPrLabels(context) {
+  const labels = ghApi(
+    `/repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/labels`
+  ) || [];
+  return labels.map(l => l.name);
+}
+
+// ---- CLI entry point ------------------------------------------------------
+
+/**
+ * Main entry point
+ */
+export function main() {
+  const context = loadGitHubContext();
+
+  if (!context.issue.number) {
+    const result = { spawn: false, reason: 'Not a pull request event' };
+    console.log(JSON.stringify(result));
+    return result;
+  }
+
+  const force = process.env.FORCE_DATA_CLASSIFICATION_AGENT === 'true';
+  const files = fetchPrFiles(context);
+  const labels = fetchPrLabels(context);
+
+  const result = shouldSpawnDataClassification(files, { labels, force });
+
+  logger.error(`Decision: spawn=${result.spawn}, reason="${result.reason}"`);
+  console.log(JSON.stringify(result));
+
+  return result;
+}
+
+// Execute main() only when run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    logger.error(`Error: ${error.message}`);
+    console.log(JSON.stringify({ spawn: false, reason: `Error: ${error.message}` }));
+    process.exit(0);
+  }
+}


### PR DESCRIPTION
## Summary

- Add automated enforcement of Reown's Data Classification and Management Policy (SOC 1 Type II) as a conditional sub-agent in the auto-review system
- Follows the exact pattern established by license compliance (#67) and breaking changes (#66)
- Agent covers 6 focus areas: critical data handling, confidential data (PII), data in transit/use, infrastructure compliance, and data retention
- Heuristic triggers on Terraform/IaC, k8s/Helm, env/secret files, DB schemas, API routes, and sensitive patch keywords
- 44 new tests, all 159 tests passing

## Test plan

- [x] `pnpm test` — all 159 tests pass (44 new + 115 existing)
- [x] No quoted heredoc delimiters in action.yml
- [x] `extract-findings-from-comment.js` existing tests still pass with new `dcl-` prefix
- [ ] Verify in a real PR that the heuristic correctly triggers/skips based on file patterns
- [ ] Verify force flag (`force_data_classification_agent: true`) spawns the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)