### PR TITLE
chore(auto-review): add dependabot[bot] to allowed_bots in Claude review actions

### DIFF
--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -340,7 +340,7 @@ runs:
         prompt: ${{ env.REVIEW_PROMPT }}
         track_progress: true
         claude_args: --model ${{ inputs.model }} --allowedTools "Read,Glob,Grep,Task,WebFetch"
-        allowed_bots: devin-ai-integration[bot]
+        allowed_bots: devin-ai-integration[bot],dependabot[bot]
 
     - name: Extract findings from Claude's comment
       if: inputs.comment_pr_findings == 'true'

--- a/claude/terraform-plan-review/action.yml
+++ b/claude/terraform-plan-review/action.yml
@@ -134,4 +134,4 @@ runs:
           Be thorough in the detailed section but keep the top summary concise (2-3 lines max). Use emojis for readability.
         track_progress: true
         claude_args: --model ${{ inputs.model }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(*)"
-        allowed_bots: devin-ai-integration[bot]
+        allowed_bots: devin-ai-integration[bot],dependabot[bot]


### PR DESCRIPTION
## Summary
- Add `dependabot[bot]` to `allowed_bots` in `claude/auto-review` and `claude/terraform-plan-review` actions
- This allows Dependabot PRs to trigger automated Claude reviews (code review and Terraform plan analysis)

## Test plan
- [ ] Verify a Dependabot PR triggers the auto-review action
- [ ] Verify a Dependabot Terraform PR triggers the terraform-plan-review action

🤖 Generated with [Claude Code](https://claude.com/claude-code)