### PR TITLE
feat(maestro): split KYC dismiss test for webview and in-app browser

### DIFF
--- a/maestro/pay-tests/.maestro/pay_kyc_browser_dismiss.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_browser_dismiss.yaml
@@ -1,0 +1,58 @@
+appId: ${APP_ID}
+name: WalletConnect Pay - KYC Browser Dismiss
+tags:
+  - pay-browser
+---
+# Create payment via API (multi-option, KYC merchant)
+- runScript:
+    file: scripts/create-payment.js
+    env:
+      WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
+      WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
+- startRecording: "WalletConnect Pay KYC Browser Dismiss"
+# Open wallet, paste payment URL
+- runFlow:
+    file: flows/pay_open_and_paste_url.yaml
+# Wait for payment options to load
+- extendedWaitUntil:
+    visible:
+      id: "pay-merchant-info"
+    timeout: 15000
+# Verify first option is pre-selected
+- assertVisible:
+    id: "pay-option-0-selected"
+# Tap Continue to open collect data in-app browser
+- tapOn:
+    id: "pay-button-continue"
+# Wait for the in-app browser to load
+- extendedWaitUntil:
+    visible: "Add your personal details"
+    timeout: 30000
+# Close the in-app browser (platform-specific button)
+# Android: "close_button", iOS: "Close"
+- runFlow:
+    when:
+      visible:
+        id: "close_button"
+    commands:
+      - tapOn:
+          id: "close_button"
+- runFlow:
+    when:
+      visible: "Close"
+    commands:
+      - tapOn: "Close"
+# Verify we're back at the payment options screen
+- extendedWaitUntil:
+    visible:
+      id: "pay-option-0-selected"
+    timeout: 10000
+# Dismiss the modal
+- tapOn:
+    id: "pay-button-close"
+# Verify modal is dismissed and we're back at the main wallet screen
+- extendedWaitUntil:
+    visible:
+      id: "button-scan"
+    timeout: 10000
+- stopRecording

--- a/maestro/pay-tests/.maestro/pay_kyc_webview_dismiss.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_webview_dismiss.yaml
@@ -1,7 +1,7 @@
 appId: ${APP_ID}
-name: WalletConnect Pay - KYC Header Buttons
+name: WalletConnect Pay - KYC Webview Dismiss
 tags:
-  - pay
+  - pay-webview
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:
@@ -10,7 +10,7 @@ tags:
       WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
 
-- startRecording: "WalletConnect Pay KYC Header Buttons"
+- startRecording: "WalletConnect Pay KYC Webview Dismiss"
 
 # Open wallet, paste payment URL
 - runFlow:

--- a/maestro/pay-tests/README.md
+++ b/maestro/pay-tests/README.md
@@ -152,13 +152,16 @@ Each merchant pair represents a different test configuration. The tests use thes
 | `pay_multiple_options_kyc` | Multiple options with KYC webview | MULTI_KYC |
 | `pay_cancel_from_review` | Server-side cancellation on review screen | SINGLE_NOKYC |
 | `pay_cancel_from_kyc` | Server-side cancellation during KYC | MULTI_KYC |
-| `pay_kyc_back_navigation` | Back/close button navigation in KYC | MULTI_KYC |
+| `pay_kyc_webview_dismiss` | Webview back/close button navigation in KYC (tag: `pay-webview`) | MULTI_KYC |
+| `pay_kyc_browser_dismiss` | In-app browser dismiss during KYC (tag: `pay-browser`) | MULTI_KYC |
 | `pay_insufficient_funds` | Payment amount exceeds wallet balance | SINGLE_NOKYC |
 | `pay_double_scan` | Re-scan same QR after completion | SINGLE_NOKYC |
 | `pay_expired_link` | Hardcoded expired payment URL | None (hardcoded) |
 | `pay_cancelled` | Hardcoded cancelled payment URL | None (hardcoded) |
 
-All flows are tagged with `pay` for filtering via `--include-tags`.
+Most flows are tagged with `pay`. The KYC dismiss tests use platform-specific tags:
+- **RN / Kotlin / Swift:** `--include-tags pay,pay-webview` (includes `pay_kyc_webview_dismiss`)
+- **Flutter:** `--include-tags pay,pay-browser` (includes `pay_kyc_browser_dismiss`)
 
 ## Deep Link Support
 


### PR DESCRIPTION
## Summary
- Renames `pay_kyc_back_navigation` to `pay_kyc_webview_dismiss` with tag `pay-webview` for platforms using native WebView (RN, Kotlin, Swift)
- Adds new `pay_kyc_browser_dismiss` test with tag `pay-browser` for Flutter, which uses InAppBrowser instead of WebView
- Updates README test catalog with both tests and platform-specific tag usage instructions

## CI usage
- **RN / Kotlin / Swift:** `--include-tags pay,pay-webview`
- **Flutter:** `--include-tags pay,pay-browser`

## Test plan
- [ ] Verify `pay_kyc_webview_dismiss` runs correctly on RN/Kotlin/Swift with `--include-tags pay,pay-webview`
- [ ] Verify `pay_kyc_browser_dismiss` runs correctly on Flutter with `--include-tags pay,pay-browser`
- [ ] Confirm neither KYC dismiss test runs with just `--include-tags pay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)