### PR TITLE
chore(maestro): change --debug-output path from test runs

### DIFF
--- a/maestro/pay-tests/README.md
+++ b/maestro/pay-tests/README.md
@@ -260,6 +260,7 @@ steps:
           --env WPAY_MERCHANT_ID_MULTI_KYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }}" \
           --include-tags pay \
           --test-output-dir maestro-artifacts \
+          --debug-output "${RUNNER_TEMP}/maestro-debug" \
           .maestro/
 
   - name: Upload Maestro artifacts

--- a/maestro/pay-tests/README.md
+++ b/maestro/pay-tests/README.md
@@ -260,7 +260,6 @@ steps:
           --env WPAY_MERCHANT_ID_MULTI_KYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }}" \
           --include-tags pay \
           --test-output-dir maestro-artifacts \
-          --debug-output maestro-artifacts \
           .maestro/
 
   - name: Upload Maestro artifacts

--- a/maestro/run/action.yml
+++ b/maestro/run/action.yml
@@ -54,7 +54,6 @@ runs:
           --env WPAY_MERCHANT_ID_MULTI_KYC="${{ inputs.wpay-merchant-id-multi-kyc }}" \
           --include-tags "${{ inputs.tags }}" \
           --test-output-dir maestro-artifacts \
-          --debug-output maestro-artifacts \
           "${{ inputs.maestro-dir }}" 2>&1 | tee maestro-output.log
 
     - name: Upload Maestro artifacts

--- a/maestro/run/action.yml
+++ b/maestro/run/action.yml
@@ -54,6 +54,7 @@ runs:
           --env WPAY_MERCHANT_ID_MULTI_KYC="${{ inputs.wpay-merchant-id-multi-kyc }}" \
           --include-tags "${{ inputs.tags }}" \
           --test-output-dir maestro-artifacts \
+          --debug-output "${RUNNER_TEMP}/maestro-debug" \
           "${{ inputs.maestro-dir }}" 2>&1 | tee maestro-output.log
 
     - name: Upload Maestro artifacts


### PR DESCRIPTION
## Summary
- Change `--debug-output` path to a tmp folder

## Test plan
- [ ] Verify Maestro test runs still upload artifacts (test output dir is unaffected).