### PR TITLE
feat(maestro): allow overriding pay API base URL in pay-tests

### DIFF
--- a/maestro/pay-tests/.maestro/pay_expired_link.yaml
+++ b/maestro/pay-tests/.maestro/pay_expired_link.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 # Use WPAY_EXPIRED_GATEWAY_URL when set (e.g. local pay-core CI seeds a fresh
 # expired payment); otherwise fall back to the hardcoded prod-expired link.
-- evalScript: ${output.gateway_url = WPAY_EXPIRED_GATEWAY_URL || 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}
+- evalScript: ${output.gateway_url = (typeof WPAY_EXPIRED_GATEWAY_URL !== 'undefined' && WPAY_EXPIRED_GATEWAY_URL) ? WPAY_EXPIRED_GATEWAY_URL : 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}
 
 - startRecording: "WalletConnect Pay Expired Link"
 

--- a/maestro/pay-tests/.maestro/pay_expired_link.yaml
+++ b/maestro/pay-tests/.maestro/pay_expired_link.yaml
@@ -3,8 +3,9 @@ name: WalletConnect Pay - Expired Link
 tags:
   - pay
 ---
-# Use a hardcoded expired payment URL (no API call needed)
-- evalScript: ${output.gateway_url = 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}
+# Use WPAY_EXPIRED_GATEWAY_URL when set (e.g. local pay-core CI seeds a fresh
+# expired payment); otherwise fall back to the hardcoded prod-expired link.
+- evalScript: ${output.gateway_url = WPAY_EXPIRED_GATEWAY_URL || 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}
 
 - startRecording: "WalletConnect Pay Expired Link"
 

--- a/maestro/pay-tests/.maestro/scripts/cancel-payment.js
+++ b/maestro/pay-tests/.maestro/scripts/cancel-payment.js
@@ -1,11 +1,16 @@
 // Cancels a WalletConnect Pay payment via the API.
 // Expects WPAY_CUSTOMER_KEY, WPAY_MERCHANT_ID, and PAYMENT_ID env vars from Maestro.
+// Optional WPAY_PAY_API_URL overrides the API base URL (default: prod).
 
 if (typeof WPAY_CUSTOMER_KEY === 'undefined') throw new Error('Missing env var: WPAY_CUSTOMER_KEY');
 if (typeof WPAY_MERCHANT_ID === 'undefined') throw new Error('Missing env var: WPAY_MERCHANT_ID');
 if (typeof PAYMENT_ID === 'undefined') throw new Error('Missing env var: PAYMENT_ID');
 
-var response = http.post('https://api.pay.walletconnect.com/v1/payments/' + PAYMENT_ID + '/cancel', {
+var baseUrl = (typeof WPAY_PAY_API_URL !== 'undefined' && WPAY_PAY_API_URL)
+  ? WPAY_PAY_API_URL
+  : 'https://api.pay.walletconnect.com';
+
+var response = http.post(baseUrl + '/v1/payments/' + PAYMENT_ID + '/cancel', {
   headers: {
     'Content-Type': 'application/json',
     'Api-Key': WPAY_CUSTOMER_KEY,

--- a/maestro/pay-tests/.maestro/scripts/create-payment.js
+++ b/maestro/pay-tests/.maestro/scripts/create-payment.js
@@ -1,11 +1,16 @@
 // Creates a WalletConnect Pay payment via the API.
 // Expects WPAY_CUSTOMER_KEY and WPAY_MERCHANT_ID env vars from Maestro.
+// Optional WPAY_PAY_API_URL overrides the API base URL (default: prod).
 // Sets output.gateway_url and output.payment_id for use in subsequent flow steps.
 
 if (typeof WPAY_CUSTOMER_KEY === 'undefined') throw new Error('Missing env var: WPAY_CUSTOMER_KEY');
 if (typeof WPAY_MERCHANT_ID === 'undefined') throw new Error('Missing env var: WPAY_MERCHANT_ID');
 
-var response = http.post('https://api.pay.walletconnect.com/v1/payments', {
+var baseUrl = (typeof WPAY_PAY_API_URL !== 'undefined' && WPAY_PAY_API_URL)
+  ? WPAY_PAY_API_URL
+  : 'https://api.pay.walletconnect.com';
+
+var response = http.post(baseUrl + '/v1/payments', {
   headers: {
     'Content-Type': 'application/json',
     'Api-Key': WPAY_CUSTOMER_KEY,


### PR DESCRIPTION
## Summary

Parameterize the shared Pay Maestro test scripts so cross-repo callers can point the test orchestration at a non-prod pay-core instance:

- **`scripts/create-payment.js`** and **`scripts/cancel-payment.js`** now read an optional `WPAY_PAY_API_URL` env var; falls back to `https://api.pay.walletconnect.com` when unset (existing behavior preserved).
- **`pay_expired_link.yaml`** now reads `WPAY_EXPIRED_GATEWAY_URL` with the existing hardcoded prod-expired link as fallback.

## Why

`WalletConnect/pay-core`'s upcoming PR-time E2E workflow (`wx-pay-e2e-maestro.yml`) builds the wallet against a freshly-seeded **local** pay-core on the runner, but currently the shared scripts hardcode `https://api.pay.walletconnect.com`. The test harness creates the payment on prod while the wallet under test reads it from local pay-core — they end up looking at two different pay-cores. With this change the pay-core CI can pass `WPAY_PAY_API_URL=http://localhost:3080` plus a freshly-seeded `WPAY_EXPIRED_GATEWAY_URL` so all 12 flows can run against a single pay-core.

The wallet-repo CI (`react-native-examples/.github/workflows/ci_e2e_walletkit.yaml`) doesn't set these vars — behavior is byte-identical.

## Test plan

- [ ] Manually re-run `react-native-examples` E2E (which doesn't set the new vars) to confirm no regression in default behavior.
- [ ] Once merged, `reown-com/react-native-examples` composite action `walletkit-build-and-maestro` will be updated to plumb the two new env vars from new inputs (`pay-api-url`, `expired-gateway-url`) and bump its pinned ref of this repo. That PR is the consumer that exercises the new code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)