### PR TITLE
fix(maestro): wrap pay_expired_link evalScript in YAML double quotes

### DIFF
--- a/maestro/pay-tests/.maestro/pay_expired_link.yaml
+++ b/maestro/pay-tests/.maestro/pay_expired_link.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 # Use WPAY_EXPIRED_GATEWAY_URL when set (e.g. local pay-core CI seeds a fresh
 # expired payment); otherwise fall back to the hardcoded prod-expired link.
-- evalScript: ${output.gateway_url = (typeof WPAY_EXPIRED_GATEWAY_URL !== 'undefined' && WPAY_EXPIRED_GATEWAY_URL) ? WPAY_EXPIRED_GATEWAY_URL : 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}
+- evalScript: "${output.gateway_url = (typeof WPAY_EXPIRED_GATEWAY_URL !== 'undefined' && WPAY_EXPIRED_GATEWAY_URL) ? WPAY_EXPIRED_GATEWAY_URL : 'https://pay.walletconnect.com/?pid=pay_b8a2ecc101KNHRNWXD2VF8SGZDS7WK19ZA'}"
 
 - startRecording: "WalletConnect Pay Expired Link"
 


### PR DESCRIPTION
## Summary

The ternary form merged in #81 has a colon-space (`URL : ...`) that snakeyaml/jackson-yaml treats as a YAML mapping-value separator, breaking parse at column 142:

```
> Parsing Failed
mapping values are not allowed here
in 'reader', line 8, column 143:
... URL) ? WPAY_EXPIRED_GATEWAY_URL : 'https://pay.walletconnect.com ...
```

Wrapping the entire `${...}` expression in YAML double quotes makes the inner colon-space a string literal. The JS expression already uses single quotes inside, so no escaping is needed.

Verified locally with PyYAML — file now parses cleanly into the expected `{evalScript: "${...}"}` mapping.

## Why this matters now

Maestro aborts test loading on the first parse error, so the wallet-repo's E2E pipeline (`react-native-examples` PR #479 / `ci_e2e_walletkit.yaml`) currently fails before any flow runs — see https://github.com/reown-com/react-native-examples/actions/runs/25055572181. This fix unblocks all 12 pay flows, not just the expired-link one.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load_all(open(...))"` parses cleanly
- [ ] Re-run `react-native-examples` E2E once merged + pinned ref bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)