### PR TITLE
chore(maestro): tag KYC-submitting flows pay-needs-kyc-backend

### DIFF
--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -2,6 +2,7 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Cancel from KYC Webview
 tags:
   - pay
+  - pay-needs-kyc-backend
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -2,6 +2,7 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Multiple Options with KYC
 tags:
   - pay
+  - pay-needs-kyc-backend
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:


### PR DESCRIPTION
## Summary

Add a `pay-needs-kyc-backend` tag to the two pay-test flows that actually submit personal-details data through the KYC webview:
- `pay_multiple_options_kyc.yaml`
- `pay_cancel_from_kyc.yaml`

The third KYC-related flow (`pay_kyc_back_navigation.yaml`) only checks UI elements and navigates back without submitting, so it isn't tagged — it works fine against any pay-core.

## Why

Cross-repo callers running these flows against a **local** pay-core in CI (e.g. `WalletConnect/pay-core`'s upcoming PR-time E2E) can't satisfy the two submission flows: the KYC webview is served from the gateway base URL configured on the target pay-core, and there's no real KYC backend listening on `http://localhost:3080/...`. The wallet's webview submission breaks the contract and subsequent fetches return "Payment not found".

With the new tag, those callers can run `maestro test --include-tags pay --exclude-tags pay-needs-kyc-backend` and skip just these two while keeping the other 9 pay flows green. Callers running against deployed pay-core (WalletKit's own CI on `react-native-examples`, pay-core's release pipeline `sub-validate.yml`) keep including everything by default — no behavior change.

## Test plan

- [ ] Verify `WalletConnect/pay-core` PR #597 (with the planned `maestro-exclude-tags=pay-needs-kyc-backend` workflow update) goes from 8/11 → 9/11 passing locally.
- [ ] No change to wallet-team CI on `react-native-examples` — those don't pass `--exclude-tags`, so all 11 still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)