### PR TITLE
Update maestro tests for new payment flows

### DIFF
--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -20,7 +20,7 @@ tags:
 # Wait for payment options to load
 - extendedWaitUntil:
     visible:
-      id: "pay-merchant-info"
+      id: "pay-select-option-header"
     timeout: 15000
 
 # Verify first option exists

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -23,13 +23,13 @@ tags:
       id: "pay-merchant-info"
     timeout: 15000
 
-# Verify first option is pre-selected
+# Verify first option exists
 - assertVisible:
-    id: "pay-option-0-selected"
+    id: "pay-option-0"
 
-# Tap Continue to go to collectData webview
+# Tap the first option to go to collectData webview
 - tapOn:
-    id: "pay-button-continue"
+    id: "pay-option-0"
 
 # Wait for KYC webview to load
 - extendedWaitUntil:

--- a/maestro/pay-tests/.maestro/pay_double_scan.yaml
+++ b/maestro/pay-tests/.maestro/pay_double_scan.yaml
@@ -32,7 +32,7 @@ tags:
 - copyTextFrom:
     id: "pay-button-pay"
 - assertTrue:
-    condition: "${maestro.copiedText == 'Pay $0.01'}"
+    condition: "${maestro.copiedText.startsWith('Pay $')}"
 
 # Tap Pay, verify success, tap "Got it!"
 - runFlow:

--- a/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
@@ -19,7 +19,7 @@ tags:
 # Wait for payment options to load
 - extendedWaitUntil:
     visible:
-      id: "pay-merchant-info"
+      id: "pay-select-option-header"
     timeout: 15000
 
 # Verify first option exists

--- a/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
@@ -22,13 +22,13 @@ tags:
       id: "pay-merchant-info"
     timeout: 15000
 
-# Verify first option is pre-selected
+# Verify first option exists
 - assertVisible:
-    id: "pay-option-0-selected"
+    id: "pay-option-0"
 
-# Tap Continue to go to collectData webview
+# Tap the first option to go to collectData webview
 - tapOn:
-    id: "pay-button-continue"
+    id: "pay-option-0"
 
 # Wait for KYC webview to load
 - extendedWaitUntil:
@@ -50,7 +50,7 @@ tags:
 # Verify we're back at the selectOption view
 - extendedWaitUntil:
     visible:
-      id: "pay-option-0-selected"
+      id: "pay-option-0"
     timeout: 10000
 
 # Dismiss the modal

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -23,41 +23,23 @@ tags:
       id: "pay-merchant-info"
     timeout: 15000
 
-# Verify first option is pre-selected (index 0)
+# Verify first option exists
 - assertVisible:
-    id: "pay-option-0-selected"
+    id: "pay-option-0"
 
 # Verify at least a second option exists (multiple options)
 - assertVisible:
     id: "pay-option-1"
 
-# Verify "Info required" badge is visible on KYC options
+# Verify info-required marker is visible on KYC options
 - assertVisible:
-    id: "pay-info-required-badge"
-
-# Verify "?" info button is visible in the header
-- assertVisible:
-    id: "pay-button-info"
+    id: "pay-option-info-required"
 
 # Select the second option (index 1)
+- copyTextFrom:
+    id: "pay-option-1"
 - tapOn:
     id: "pay-option-1"
-
-# Verify second option is now selected
-- assertVisible:
-    id: "pay-option-1-selected"
-
-# Verify first option is now deselected
-- assertVisible:
-    id: "pay-option-0"
-
-# Copy the network name from the selected option's accessibilityLabel
-- copyTextFrom:
-    id: "pay-option-1-selected"
-
-# Tap Continue to proceed
-- tapOn:
-    id: "pay-button-continue"
 
 # Handle personal details webview (KYC)
 - extendedWaitUntil:
@@ -93,7 +75,7 @@ tags:
 - copyTextFrom:
     id: "pay-button-pay"
 - assertTrue:
-    condition: "${maestro.copiedText == 'Pay $0.01'}"
+    condition: "${maestro.copiedText.startsWith('Pay $')}"
 
 # Tap Pay, verify success
 - runFlow:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -22,7 +22,7 @@ tags:
 # Wait for payment options to load
 - extendedWaitUntil:
     visible:
-      id: "pay-merchant-info"
+      id: "pay-select-option-header"
     timeout: 15000
 
 # Verify first option exists

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -11,6 +11,8 @@ tags:
       WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
 
+- clearState
+
 - startRecording: "WalletConnect Pay Multiple Options KYC"
 
 # Open wallet, paste payment URL

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
@@ -19,7 +19,7 @@ tags:
 # Wait for payment options to load
 - extendedWaitUntil:
     visible:
-      id: "pay-merchant-info"
+      id: "pay-select-option-header"
     timeout: 15000
 
 # Verify first option exists

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
@@ -22,41 +22,23 @@ tags:
       id: "pay-merchant-info"
     timeout: 15000
 
-# Verify first option is pre-selected (index 0)
+# Verify first option exists
 - assertVisible:
-    id: "pay-option-0-selected"
+    id: "pay-option-0"
 
 # Verify at least a second option exists (multiple options)
 - assertVisible:
     id: "pay-option-1"
 
-# Verify "?" info button is NOT visible (no KYC merchant)
+# Verify info-required marker is NOT visible (no KYC merchant)
 - assertNotVisible:
-    id: "pay-button-info"
-
-# Verify "info required" badge is NOT visible (no KYC)
-- assertNotVisible:
-    id: "pay-info-required-badge"
+    id: "pay-option-info-required"
 
 # Select the second option (index 1)
+- copyTextFrom:
+    id: "pay-option-1"
 - tapOn:
     id: "pay-option-1"
-
-# Verify second option is now selected
-- assertVisible:
-    id: "pay-option-1-selected"
-
-# Verify first option is now deselected
-- assertVisible:
-    id: "pay-option-0"
-
-# Copy the network name from the selected option's accessibilityLabel
-- copyTextFrom:
-    id: "pay-option-1-selected"
-
-# Tap Continue to proceed
-- tapOn:
-    id: "pay-button-continue"
 
 # No KYC — goes straight to review screen
 # Verify review screen shows the same token we selected
@@ -67,7 +49,7 @@ tags:
 - copyTextFrom:
     id: "pay-button-pay"
 - assertTrue:
-    condition: "${maestro.copiedText == 'Pay $0.01'}"
+    condition: "${maestro.copiedText.startsWith('Pay $')}"
 
 # Tap Pay, verify success
 - runFlow:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
@@ -10,6 +10,8 @@ tags:
       WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_NOKYC}
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_NOKYC}
 
+- clearState
+
 - startRecording: "WalletConnect Pay Multiple Options No KYC"
 
 # Open wallet, paste payment URL

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -32,7 +32,7 @@ tags:
 - copyTextFrom:
     id: "pay-button-pay"
 - assertTrue:
-    condition: "${maestro.copiedText == 'Pay $0.01'}"
+    condition: "${maestro.copiedText.startsWith('Pay $')}"
 
 # Tap Pay, verify success
 - runFlow:

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -10,6 +10,8 @@ tags:
       WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_SINGLE_NOKYC}
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_SINGLE_NOKYC}
 
+- clearState
+
 - startRecording: "WalletConnect Pay Single Option No KYC"
 
 # Open wallet, paste payment URL

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -32,7 +32,7 @@ tags:
 - copyTextFrom:
     id: "pay-button-pay"
 - assertTrue:
-    condition: "${maestro.copiedText == 'Pay $0.01'}"
+    condition: "${maestro.copiedText.startsWith('Pay $')}"
 
 # Tap Pay, verify success
 - runFlow:

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -10,6 +10,8 @@ tags:
       WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_SINGLE_NOKYC}
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_SINGLE_NOKYC}
 
+- clearState
+
 - startRecording: "WalletConnect Pay Single Option No KYC Deep Link"
 
 # Open wallet via deep link with payment URL


### PR DESCRIPTION
## Summary
- update shared pay Maestro flows to match the WalletKit pay UX changes from reown-com/react-native-examples#480
- remove stale `*-selected` and `pay-button-continue` selectors from multi-option/KYC flows
- switch info-required checks to the new `pay-option-info-required` test ID
- loosen exact pay-button amount assertions to accept the new displayed totals

## Why
The wallet PR changed the payment-option navigation and test IDs, so the shared pay flows in `WalletConnect/actions` needed to be updated to keep the E2E suite aligned.

## Validation
- parsed all 7 edited Maestro YAML files with Ruby `YAML.load_file`
