### PR TITLE
chore(maestro): bump pay-tests load timeouts to 30s

### DIFF
--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -21,7 +21,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-select-option-header"
-    timeout: 15000
+    timeout: 30000
 
 # Verify first option exists
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_review.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_review.yaml
@@ -20,7 +20,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-merchant-info"
-    timeout: 15000
+    timeout: 30000
 
 # Single option auto-selects — verify review screen
 - extendedWaitUntil:

--- a/maestro/pay-tests/.maestro/pay_cancelled.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancelled.yaml
@@ -27,7 +27,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-result-container"
-    timeout: 15000
+    timeout: 30000
 
 # Verify cancelled icon is shown
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_double_scan.yaml
+++ b/maestro/pay-tests/.maestro/pay_double_scan.yaml
@@ -22,7 +22,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-merchant-info"
-    timeout: 15000
+    timeout: 30000
 
 # Single option auto-selects — verify pay button
 - extendedWaitUntil:
@@ -64,7 +64,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-result-container"
-    timeout: 20000
+    timeout: 30000
 
 # Verify generic error icon is shown (not success)
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_expired_link.yaml
+++ b/maestro/pay-tests/.maestro/pay_expired_link.yaml
@@ -17,7 +17,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-result-container"
-    timeout: 15000
+    timeout: 30000
 
 # Verify expired icon is shown
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_insufficient_funds.yaml
+++ b/maestro/pay-tests/.maestro/pay_insufficient_funds.yaml
@@ -21,7 +21,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-result-container"
-    timeout: 15000
+    timeout: 30000
 
 # Verify insufficient funds icon is shown
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
@@ -20,7 +20,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-select-option-header"
-    timeout: 15000
+    timeout: 30000
 
 # Verify first option exists
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -23,7 +23,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-select-option-header"
-    timeout: 15000
+    timeout: 30000
 
 # Verify first option exists
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
@@ -22,7 +22,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-select-option-header"
-    timeout: 15000
+    timeout: 30000
 
 # Verify first option exists
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -22,7 +22,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-merchant-info"
-    timeout: 15000
+    timeout: 30000
 
 # Single option auto-selects — go straight to review screen
 

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -22,7 +22,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "pay-merchant-info"
-    timeout: 15000
+    timeout: 30000
 
 # Single option auto-selects — go straight to review screen
 


### PR DESCRIPTION
## Summary
- Doubles `extendedWaitUntil` timeouts (15s/20s → 30s) on initial-load checks across all 11 pay-tests flows to reduce flakes when `pay-select-option-header`, `pay-merchant-info`, or `pay-result-container` take longer than expected to appear.

## Test plan
- [ ] Run pay-tests in CI and confirm no regressions