### PR TITLE
fix(auto-review): allow walletconnect-agent bot to trigger reviews

### DIFF
--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -38,7 +38,7 @@ inputs:
   allowed_bots:
     description: "Comma-separated bot actors allowed to trigger the review, or '*' for all bots"
     required: false
-    default: "devin-ai-integration[bot],walletconnect-agent"
+    default: "devin-ai-integration[bot],walletconnect-agent[bot]"
 
 runs:
   using: "composite"

--- a/claude/auto-review/action.yml
+++ b/claude/auto-review/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Force data classification agent regardless of heuristic"
     required: false
     default: "false"
+  allowed_bots:
+    description: "Comma-separated bot actors allowed to trigger the review, or '*' for all bots"
+    required: false
+    default: "devin-ai-integration[bot],walletconnect-agent"
 
 runs:
   using: "composite"
@@ -340,7 +344,7 @@ runs:
         prompt: ${{ env.REVIEW_PROMPT }}
         track_progress: true
         claude_args: --model ${{ inputs.model }} --allowedTools "Read,Glob,Grep,Task,WebFetch"
-        allowed_bots: devin-ai-integration[bot]
+        allowed_bots: ${{ inputs.allowed_bots }}
 
     - name: Extract findings from Claude's comment
       if: inputs.comment_pr_findings == 'true'


### PR DESCRIPTION
## Problem

Auto-review failed immediately on PRs opened by the `walletconnect-agent` bot account, e.g. [infra run #26499707098](https://github.com/WalletConnect/infra/actions/runs/26499707098/job/78036670952?pr=497):

```
Action failed with error: Workflow initiated by non-human actor: walletconnect-agent (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action`'s `allowed_bots` only listed `devin-ai-integration[bot]`, so any review triggered by our own automation bot was rejected before it could run.

## Fix

- Add an `allowed_bots` input (default `devin-ai-integration[bot],walletconnect-agent`) so consumers can override per-repo or pass `*`.
- Wire the `claude-code-action` step to `${{ inputs.allowed_bots }}` instead of the hardcoded single bot.

## Validation

Confirmed against [`claude-code-action`'s `isAllowedBot`](https://github.com/anthropics/claude-code-action/blob/v1/src/github/validation/actor.ts): both the allowlist entries and the actor login are lowercased and have a trailing `[bot]` stripped before comparison. The error's `botName` is built the same way and printed `walletconnect-agent`, so the entry matches regardless of whether the raw actor login carries a `[bot]` suffix.