### PR TITLE
fix(terraform-plan-review): allow walletconnect-agent bot to trigger reviews

### DIFF
--- a/claude/terraform-plan-review/action.yml
+++ b/claude/terraform-plan-review/action.yml
@@ -16,6 +16,10 @@ inputs:
   terraform_plan_log_file:
     description: "Optional: Path to file containing raw terraform plan logs (warnings/errors) for diagnostics"
     required: false
+  allowed_bots:
+    description: "Comma-separated bot actors allowed to trigger the review, or '*' for all bots"
+    required: false
+    default: "devin-ai-integration[bot],walletconnect-agent[bot]"
 
 runs:
   using: "composite"
@@ -134,4 +138,4 @@ runs:
           Be thorough in the detailed section but keep the top summary concise (2-3 lines max). Use emojis for readability.
         track_progress: true
         claude_args: --model ${{ inputs.model }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(*)"
-        allowed_bots: devin-ai-integration[bot]
+        allowed_bots: ${{ inputs.allowed_bots }}


### PR DESCRIPTION
## Problem

Same root cause as #86, different action. The Terraform Plan Review failed on bot-authored PRs, e.g. [infra run #26508259237 → AI Plan Review job](https://github.com/WalletConnect/infra/actions/runs/26508259237/job/78067002608):

```
Action failed with error: Workflow initiated by non-human actor: walletconnect-agent (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude/terraform-plan-review` still hardcoded `allowed_bots: devin-ai-integration[bot]`, so plan reviews on PRs opened by `walletconnect-agent[bot]` were rejected before running. (#86 fixed only the auto-review action.)

## Fix

- Add an `allowed_bots` input (default `devin-ai-integration[bot],walletconnect-agent[bot]`).
- Wire the `claude-code-action` step to `${{ inputs.allowed_bots }}` instead of the hardcoded single bot.

Mirrors the change in #86.