### PR TITLE
chore(maestro): bump deeplink-flow cold-start timeout 30s → 60s

### DIFF
--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -18,11 +18,21 @@ tags:
 - runFlow:
     file: flows/pay_open_via_deeplink.yaml
 
-# Wait for payment options to load
+# Wait for payment options to load.
+#
+# Higher timeout than the paste-URL flows because this is the only
+# cold-start path in the suite: pay_open_via_deeplink.yaml does
+# stopApp + openLink, so the wallet's first sign of life is the OS
+# routing the Android intent into a fresh process — ActivityManager
+# fork, Hermes init, RN bridge, deep-link router, then the API call.
+# On a contended CI emulator the new process can take 20-30s to
+# attach (sometimes failing with `Process ... failed to attach` and
+# requiring re-fork), which left the 30s budget consistently tight
+# (pay-core run 26570588681).
 - extendedWaitUntil:
     visible:
       id: "pay-merchant-info"
-    timeout: 30000
+    timeout: 60000
 
 # Single option auto-selects — go straight to review screen
 


### PR DESCRIPTION
## Summary

- Bumps the `extendedWaitUntil` timeout for `pay-merchant-info` in `pay_single_option_nokyc_deeplink.yaml` from 30s → 60s.
- Only affects the one deep-link cold-start flow. Paste-URL flows stay at 30s — they don't share this path.

## Why

`pay_single_option_nokyc_deeplink.yaml` is the only flow in the suite that opens the wallet from cold via Android intent. `flows/pay_open_via_deeplink.yaml` does `stopApp` + `openLink`, which means the wallet's first sign of life is the OS routing the intent into a fresh process. Every other flow goes through `pay_open_and_paste_url.yaml`'s `launchApp` (which only starts the app if it isn't already running) so the process is typically warm.

The cold-start path is:

1. `stopApp` kills the existing wallet process
2. `openLink` fires an Android intent for the gateway URL
3. ActivityManager forks a new process from zygote
4. Process attaches to `system_server`, loads APK, starts Hermes
5. RN bridge boots, JS bundle loads (~10MB Hermes bytecode)
6. Deep-link router parses the URL, navigates to PaymentEvent screen
7. PaymentEvent fetches `/gateway/payment/{id}` from pay-core
8. Merchant info component renders → `pay-merchant-info` visible

On a contended GHA Ubuntu runner with `reactivecircus/android-emulator-runner` (4GB RAM, swiftshader GPU, x86_64 API 34), this takes 20-40s reliably. Worst case the new process hits `ActivityManager: Process ... failed to attach` and gets re-forked — that adds ~10s on top.

## Evidence

pay-core CD run [26570588681](https://github.com/WalletConnect/pay-core/actions/runs/26570588681/job/78278044790) on `b01acd4e` (which pins react-native-examples@`dd44674` → this actions ref @`afc741fb`):

- 10/11 flows passed
- 1/11 failed: `WalletConnect Pay - Single Option No KYC (Deep Link) (36s) (Assertion is false: id: pay-merchant-info is visible)`
- Failure screenshot: wallet still on splash screen
- Logcat at the failure window:
  ```
  05-28 11:45:24 W ActivityManager: setHasOverlayUi called on unknown pid: 7326
  05-28 11:45:35 W ActivityManager: Process ProcessRecord{...:com.walletconnect.web3wallet.rnsample.internal/u0a141} failed to attach
  ```
  The new wallet process failed to attach to `system_server` on first fork. ActivityManager retried — by the time Hermes was up and the API call returned, the 30s budget was already gone.

## Tradeoff

60s extra worst-case wait time on this single flow, only when it's slow. Other flows are unaffected. The new ceiling is still well below the suite's overall timeout.

## Test plan

- [ ] reown-com/react-native-examples `ci_e2e_walletkit.yaml` (uses this ref via `walletkit-build-and-maestro`) stays green on the deep-link flow over a few runs
- [ ] reown-kotlin `ci_e2e_pay_tests.yml` (also uses this ref) stays green
- [ ] pay-core `sub-validate.yml` (PR [#630](https://github.com/WalletConnect/pay-core/pull/630)) soak with new ref shows ≥95% pass on the deep-link flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)