### PR TITLE
chore(maestro): bump pay_open_and_paste_url button-scan timeout 15s → 60s

### DIFF
--- a/maestro/pay-tests/.maestro/flows/pay_open_and_paste_url.yaml
+++ b/maestro/pay-tests/.maestro/flows/pay_open_and_paste_url.yaml
@@ -9,11 +9,24 @@ appId: ${APP_ID}
     permissions:
       all: allow
 
-# Wait for the app to fully load before interacting
+# Wait for the app to fully load before interacting.
+#
+# Higher timeout than a typical screen wait because this is the first
+# render after `clearState` (force-stops the app), so `launchApp`
+# triggers a full cold start: ActivityManager fork, attach to
+# system_server, APK load, Hermes init, RN bridge, JS bundle, home
+# screen render.
+#
+# On a contended CI emulator the first fork can hit `ActivityManager:
+# Process ... failed to attach`, ActivityManager re-forks, and total
+# time-to-render becomes ~30-40s. The 15s budget was consistently
+# tight on pay-core CD runs 26577564785 and 26580944640 (both attempts
+# of the retry wrapper failed here, always at exactly 20s, always with
+# a black-screen — the re-fork hadn't finished rendering).
 - extendedWaitUntil:
     visible:
       id: "button-scan"
-    timeout: 15000
+    timeout: 60000
 
 # Tap scan button to open scanner options modal
 - tapOn:


### PR DESCRIPTION
## Summary

Mirror of [#88](https://github.com/WalletConnect/actions/pull/88) for the paste-URL cold-start path. Bumps the \`extendedWaitUntil\` timeout for \`button-scan\` in \`pay_open_and_paste_url.yaml\` from 15s → 60s.

## Why

Every flow that uses \`pay_open_and_paste_url.yaml\` runs \`clearState\` first (in the parent flow). \`clearState\` force-stops the wallet — so the subsequent \`launchApp\` triggers a full cold start, not a foreground:

1. ActivityManager fork from zygote
2. Process attach to \`system_server\`
3. APK load, Hermes init
4. RN bridge boot, JS bundle (~10MB Hermes bytecode)
5. Home screen render → \`button-scan\` visible

On a contended GHA emulator the first fork can hit \`ActivityManager: Process ... failed to attach\`, ActivityManager re-forks, and total time-to-render is ~30-40s. The 15s budget was consistently tight.

## Evidence

pay-core CD runs 26577564785 and [26580944640](https://github.com/WalletConnect/pay-core/actions/runs/26580944640/job/78315481185):

- Both retry attempts in run 26580944640 failed deterministically at \`Multiple Options No KYC\` flow, always after exactly 20s
- Failure assertion: \`Assertion is false: id: button-scan is visible\`
- Screenshot: black screen (process forked, not yet attached/rendered)
- Logcat at 15:05:13:
  \`\`\`
  ActivityManager: Process ProcessRecord{... :com.walletconnect.web3wallet.rnsample.internal} failed to attach
  \`\`\`
  RN errors don't appear until 15:05:51 — 38s after \`launchApp\`. By then the Maestro timeout had long fired.

## Tradeoff

60s extra worst-case wait time on this single shared subflow, only when the launchApp hits a cold-start race. Happy path is unaffected — \`extendedWaitUntil\` exits as soon as the element renders, typically <5s on a warm process.

## Test plan

- [ ] reown-com/react-native-examples \`ci_e2e_walletkit.yaml\` hourly schedule keeps producing green runs (this affects every flow that uses the shared subflow — i.e. all 10 of the non-deeplink flows)
- [ ] reown-kotlin \`ci_e2e_pay_tests.yml\` same
- [ ] pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630) soak ≥10 runs at ≥95% pass after \`WALLETKIT_RN_REF\` is bumped to a SHA that includes this

🤖 Generated with [Claude Code](https://claude.com/claude-code)