### PR TITLE
metrics: daily Maestro E2E KPI digest to Slack

### DIFF
--- a/.github/workflows/maestro-kpi-aggregate.yml
+++ b/.github/workflows/maestro-kpi-aggregate.yml
@@ -1,0 +1,89 @@
+name: 📊 Maestro E2E KPIs (aggregate + post to Slack)
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # 09:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maestro-kpi-aggregate
+  cancel-in-progress: false
+
+jobs:
+  aggregate:
+    name: Compute KPIs and post to Slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Cross-org read across the 5 tracked SDK / backend repos.
+      GH_TOKEN: ${{ secrets.KPI_GITHUB_PAT }}
+      SLACK_KPI_WEBHOOK_URL: ${{ secrets.SLACK_KPI_WEBHOOK_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate secrets
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "${GH_TOKEN:-}" ]] && missing+=("KPI_GITHUB_PAT")
+          [[ -z "${SLACK_KPI_WEBHOOK_URL:-}" ]] && missing+=("SLACK_KPI_WEBHOOK_URL")
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          gh auth status 2>&1 | head -5
+
+      # Retrieve yesterday's pass-rate output for the "2 consecutive days
+      # <90%" alert. Best-effort — first run + post-retention-expiry both
+      # return nothing, which is fine (the alert just won't fire).
+      - name: Download yesterday's pass rates (best-effort)
+        id: yesterday
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: kpi-pass-rate-latest
+          path: yesterday/
+          github-token: ${{ secrets.KPI_GITHUB_PAT }}
+
+      - name: Compute pass rate (7d, main)
+        run: bash metrics/scripts/kpi_pass_rate.sh > pass.jsonl
+
+      - name: Compute flake rate (7d)
+        run: bash metrics/scripts/kpi_flake_rate.sh > flake.jsonl
+
+      - name: Compute P95 feedback (7d, PR)
+        run: bash metrics/scripts/kpi_p95_feedback.sh > p95.jsonl
+
+      - name: Compute bug catches (30d)
+        run: bash metrics/scripts/kpi_bug_catches.sh > catches.jsonl
+
+      - name: Echo computed KPIs (for run-log debuggability)
+        run: |
+          echo "--- pass.jsonl ---"; cat pass.jsonl
+          echo "--- flake.jsonl ---"; cat flake.jsonl
+          echo "--- p95.jsonl ---";  cat p95.jsonl
+          echo "--- catches.jsonl ---"; cat catches.jsonl
+
+      - name: Post to Slack
+        env:
+          PASS_FILE: pass.jsonl
+          FLAKE_FILE: flake.jsonl
+          P95_FILE: p95.jsonl
+          CATCHES_FILE: catches.jsonl
+          YESTERDAY_PASS: yesterday/pass.jsonl
+        run: bash metrics/scripts/post_to_slack.sh
+
+      # Persist today's pass rates as an artifact so tomorrow's run can
+      # detect a 2-consecutive-day breach. 7-day retention is more than
+      # enough (we only ever read the most-recent artifact).
+      - name: Upload today's pass rates
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpi-pass-rate-latest
+          path: pass.jsonl
+          retention-days: 7
+          overwrite: true

--- a/.github/workflows/maestro-kpi-aggregate.yml
+++ b/.github/workflows/maestro-kpi-aggregate.yml
@@ -22,8 +22,12 @@ jobs:
       GH_TOKEN: ${{ secrets.KPI_GITHUB_PAT }}
       SLACK_KPI_WEBHOOK_URL: ${{ secrets.SLACK_KPI_WEBHOOK_URL }}
     steps:
+      # Actions pinned to commit SHA (not @vN tag) — this workflow holds a
+      # cross-org PAT, so a hijacked/force-pushed action tag would have
+      # high blast radius. Other workflows in this repo use tags; bump
+      # this one when the actions release a meaningful new version.
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Validate secrets
         run: |
@@ -43,7 +47,7 @@ jobs:
       - name: Download yesterday's pass rates (best-effort)
         id: yesterday
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: kpi-pass-rate-latest
           path: yesterday/
@@ -81,7 +85,7 @@ jobs:
       # detect a 2-consecutive-day breach. 7-day retention is more than
       # enough (we only ever read the most-recent artifact).
       - name: Upload today's pass rates
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: kpi-pass-rate-latest
           path: pass.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.log
 coverage/
 .DS_Store
+.idea/

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,6 +1,6 @@
 # Maestro E2E KPIs
 
-Daily Slack post (09:00 UTC, `#e2e-kpis`) tracking four KPIs across the WalletConnect Pay Maestro E2E suites in five repos. Design doc: [WalletConnect Pay Maestro E2E KPIs — measurement plan](https://walletconnect.notion.site/WalletConnect-Pay-Maestro-E2E-KPIs-measurement-plan-35d3a661771e81f1a78cec0019f8afbd).
+Daily Slack post (09:00 UTC, `#wx-e2e-kpis`) tracking four KPIs across the WalletConnect Pay Maestro E2E suites in five repos. Design doc: [WalletConnect Pay Maestro E2E KPIs — measurement plan](https://walletconnect.notion.site/WalletConnect-Pay-Maestro-E2E-KPIs-measurement-plan-35d3a661771e81f1a78cec0019f8afbd).
 
 ## Layout
 
@@ -30,7 +30,8 @@ Edit `config/workflows.json`. Each entry needs:
 | `workflow_path` | yes | `.github/workflows/foo.yml` — stable across renames |
 | `label` | yes | Shown in the Slack table column |
 | `platform` | yes | Used to aggregate bug-catches |
-| `job_pattern` | no | Bash regex; when set, the conclusion is read from the matching **job** inside each workflow run rather than the run's overall status. Used for reusable workflows like pay-core's `sub-validate.yml` where one job of many is in scope |
+| `branch` | no | When set (e.g. `"main"`), pass/flake/bug-catch filter to that branch. Omit for workflows that don't fire on push (SDK repos are PR-trigger only). |
+| `job_pattern` | no | Bash regex; when set, the conclusion is read from the matching **job** inside each workflow run rather than the run's overall status. Used when one job of many is in scope, including jobs nested inside called reusable workflows (e.g. pay-core's Maestro CD job lives inside `sub-validate.yml`, surfaced via the `event_release.yml` parent run). |
 
 Re-running the workflow (`gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions`) picks up the config without redeploy.
 
@@ -40,16 +41,16 @@ Re-running the workflow (`gh workflow run maestro-kpi-aggregate.yml --repo Walle
 gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions
 ```
 
-Posts to the same `#e2e-kpis` channel as the cron run. Useful for testing config changes.
+Posts to the same `#wx-e2e-kpis` channel as the cron run. Useful for testing config changes.
 
 ## Secrets
 
-Both set as **organization** secrets on `WalletConnect` (granted to this repo):
+Both set as **repository** secrets on `WalletConnect/actions` (the only consumer):
 
 | Secret | What |
 |---|---|
 | `KPI_GITHUB_PAT` | Token with `actions:read` + `metadata:read` on the 5 tracked repos (kotlin/swift/flutter under `reown-com`, `reown-com/react-native-examples`, `WalletConnect/pay-core`). Fine-grained PAT preferred. |
-| `SLACK_KPI_WEBHOOK_URL` | Incoming-webhook URL for `#e2e-kpis`. |
+| `SLACK_KPI_WEBHOOK_URL` | Incoming-webhook URL for `#wx-e2e-kpis`. |
 
 ## What's a "bug catch"?
 
@@ -65,7 +66,7 @@ Heuristic, not exact. Known biases:
 
 ## Output
 
-Daily 09:00 UTC post to `#e2e-kpis`:
+Daily 09:00 UTC post to `#wx-e2e-kpis`:
 
 ```
 📊 Maestro E2E KPIs — 2026-06-03

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,110 @@
+# Maestro E2E KPIs
+
+Daily Slack post (09:00 UTC, `#e2e-kpis`) tracking four KPIs across the WalletConnect Pay Maestro E2E suites in five repos. Design doc: [WalletConnect Pay Maestro E2E KPIs — measurement plan](https://walletconnect.notion.site/WalletConnect-Pay-Maestro-E2E-KPIs-measurement-plan-35d3a661771e81f1a78cec0019f8afbd).
+
+## Layout
+
+```
+metrics/
+├── README.md                   ← you are here
+├── config/
+│   └── workflows.json          ← (repo, workflow_path, label, platform[, job_pattern]) tuples
+└── scripts/
+    ├── lib.sh                  ← shared helpers (gh, jq, date math, percentile, kpi_cell)
+    ├── kpi_pass_rate.sh        ← pass / (pass + fail), main, 7d
+    ├── kpi_flake_rate.sh       ← recovered / total failures, 7d
+    ├── kpi_p95_feedback.sh     ← P95(updated_at - created_at), PR runs, 7d
+    ├── kpi_bug_catches.sh      ← PR-time + main red→green pairs, 30d
+    └── post_to_slack.sh        ← assemble message + POST to webhook
+
+.github/workflows/maestro-kpi-aggregate.yml  ← daily cron + workflow_dispatch
+```
+
+## Adding or removing a workflow
+
+Edit `config/workflows.json`. Each entry needs:
+
+| Field | Required | Notes |
+|---|---|---|
+| `repo` | yes | `owner/name` |
+| `workflow_path` | yes | `.github/workflows/foo.yml` — stable across renames |
+| `label` | yes | Shown in the Slack table column |
+| `platform` | yes | Used to aggregate bug-catches |
+| `job_pattern` | no | Bash regex; when set, the conclusion is read from the matching **job** inside each workflow run rather than the run's overall status. Used for reusable workflows like pay-core's `sub-validate.yml` where one job of many is in scope |
+
+Re-running the workflow (`gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions`) picks up the config without redeploy.
+
+## Manual trigger
+
+```bash
+gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions
+```
+
+Posts to the same `#e2e-kpis` channel as the cron run. Useful for testing config changes.
+
+## Secrets
+
+Both set as **organization** secrets on `WalletConnect` (granted to this repo):
+
+| Secret | What |
+|---|---|
+| `KPI_GITHUB_PAT` | Token with `actions:read` + `metadata:read` on the 5 tracked repos (kotlin/swift/flutter under `reown-com`, `reown-com/react-native-examples`, `WalletConnect/pay-core`). Fine-grained PAT preferred. |
+| `SLACK_KPI_WEBHOOK_URL` | Incoming-webhook URL for `#e2e-kpis`. |
+
+## What's a "bug catch"?
+
+A red→green run pair where the diff between the two commits touches at least one non-`.github/` file. Two flavours:
+
+- **PR-time catch**: a merged PR where the workflow went red on commit A then green on commit B.
+- **Main-branch catch**: a `main` run went red, a later `main` run went green.
+
+Heuristic, not exact. Known biases:
+- Counts test-infrastructure fixes that aren't product bug fixes (e.g. a flow YAML edit).
+- Misses fixes that only touch test infrastructure under `.github/` (filter excludes them by design).
+- Per the design doc, the numbers are directionally correct, not exact.
+
+## Output
+
+Daily 09:00 UTC post to `#e2e-kpis`:
+
+```
+📊 Maestro E2E KPIs — 2026-06-03
+
+                       Pass rate   Flake rate  P95 PR feedback
+                       (7d, main)  (7d)        (7d)
+────────────────────────────────────────────────────────────
+kotlin                  ✅ 98.2%   ✅ 2.1%     ✅ 22m
+swift                   🟡 91.5%   🟡 8.3%     🟡 34m
+flutter                 ✅ 99.0%   ✅ 1.2%     ✅ 18m
+rn                      ✅ 96.8%   ✅ 3.4%     ✅ 28m
+core (PR)               ✅ 97.1%   ✅ 4.0%     ✅ 25m
+core (CD)               ✅ 96.0%   ✅ 0.0%     ✅ 28m
+────────────────────────────────────────────────────────────
+🎯 targets              ≥95%       <5%         <30m
+
+🐛 Bug catches — last 30d: 14 total (avg every 2.1 days)
+   PR-time catches:  11   •   Main-branch catches:  3
+
+   kotlin   ▓▓▓▓▓ 5
+   swift    ▓ 1
+   flutter  ▓▓ 2
+   rn       ▓▓▓ 3
+   core     ▓▓▓ 3
+
+⚠️ Attention: swift pass 91.5%, flake 8.3%, P95 34m
+```
+
+Separate threshold-breach alerts post when:
+
+| Condition | Threshold |
+|---|---|
+| Pass rate on `main` | `<90%` for 2 consecutive days |
+| Flake rate | `>10%` |
+| P95 feedback | `>45m` |
+
+## Limitations
+
+- **In-job retries are invisible.** `pay-core`'s `sub-validate.yml` wraps Maestro in a one-shot retry inside a single workflow run. From GitHub's perspective this is one attempt with one final conclusion — flake is undercounted there. Trade documented in the design doc.
+- **No backfill.** Numbers start accruing from the day this lands. The first 7d window will be partial.
+- **No per-flow breakdown.** "Which test is flakiest" is explicitly v2 work in the design doc.
+- **Personal-PAT bus factor.** v1 uses a PAT owned by one person. Migrate to a service account or GitHub App before this becomes load-bearing.

--- a/metrics/config/workflows.json
+++ b/metrics/config/workflows.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Workflows tracked by metrics/scripts/kpi_*.sh. Schema: each entry must have repo (owner/name), workflow_path (.github/workflows/file.yml — stable), label (human-readable, used in Slack), platform (groups multiple workflows under one platform row when needed). Optional branch overrides the default ('main') — SDK repos use 'develop'. Optional job_pattern is a Bash regex; when set, the conclusion is taken from the matching JOB inside each workflow run rather than the run itself — used when one job of many is in scope, including jobs nested inside called reusable workflows (e.g. pay-core's Maestro CD job lives inside sub-validate.yml which is called by sub-cd.yml which is called by event_release.yml, but the nested job is visible in event_release.yml's run-jobs endpoint).",
+  "workflows": [
+    {
+      "platform": "kotlin",
+      "label": "kotlin",
+      "repo": "reown-com/reown-kotlin",
+      "workflow_path": ".github/workflows/ci_e2e_pay_tests.yml",
+      "_note": "PR-trigger only — no branch filter, pass-rate covers all CI runs"
+    },
+    {
+      "platform": "swift",
+      "label": "swift",
+      "repo": "reown-com/reown-swift",
+      "workflow_path": ".github/workflows/ci_e2e_pay_tests.yml",
+      "_note": "PR-trigger only — no branch filter, pass-rate covers all CI runs"
+    },
+    {
+      "platform": "flutter",
+      "label": "flutter",
+      "repo": "reown-com/reown_flutter",
+      "workflow_path": ".github/workflows/ci_e2e_pay_tests.yml",
+      "_note": "PR-trigger only — no branch filter, pass-rate covers all CI runs"
+    },
+    {
+      "platform": "rn",
+      "label": "rn",
+      "repo": "reown-com/react-native-examples",
+      "workflow_path": ".github/workflows/ci_e2e_walletkit.yaml",
+      "branch": "main"
+    },
+    {
+      "platform": "core",
+      "label": "core (PR)",
+      "repo": "WalletConnect/pay-core",
+      "workflow_path": ".github/workflows/wx-pay-e2e-maestro.yml",
+      "branch": "main"
+    },
+    {
+      "platform": "core",
+      "label": "core (CD)",
+      "repo": "WalletConnect/pay-core",
+      "workflow_path": ".github/workflows/event_release.yml",
+      "branch": "main",
+      "job_pattern": "^CD / Validate Staging / WX Pay E2E Maestro - android - staging$"
+    }
+  ]
+}

--- a/metrics/scripts/kpi_bug_catches.sh
+++ b/metrics/scripts/kpi_bug_catches.sh
@@ -112,9 +112,12 @@ count_pr_time_catches() {
   local repo="$1" workflow_path="$2" job_pattern="${3:-}"
   local since_date="${SINCE%T*}"
 
-  # Merged PRs in window.
+  # Merged PRs in window. --paginate walks all pages (search/issues caps
+  # at 1000 results total regardless, which is well above our actual
+  # 30-day PR volume across the tracked repos).
   local prs
-  prs=$(gh api "search/issues?q=repo:$repo+is:pr+is:merged+merged:>=$since_date&per_page=100" \
+  prs=$(gh api --paginate \
+    "search/issues?q=repo:$repo+is:pr+is:merged+merged:>=$since_date&per_page=100" \
     --jq '.items[].number' 2>/dev/null || true)
 
   local total=0

--- a/metrics/scripts/kpi_bug_catches.sh
+++ b/metrics/scripts/kpi_bug_catches.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Compute 30-day bug-catch counts per platform.
+#
+# Heuristic (no labels required):
+#
+#   PR-time catch:  a merged PR where the workflow went red on commit A,
+#                   then green on commit B (B != A), AND the diff between
+#                   A and B contains at least one non-`.github/` file.
+#                   The non-.github filter avoids counting workflow-only
+#                   churn (e.g. pay-core PR #630's 18 CI commits).
+#
+#   Main-branch catch:  a default-branch run that went red, followed by
+#                       a later success on the same branch, with at least
+#                       one non-.github commit in the diff between SHAs.
+#
+# Each catch corresponds to "a real failure that got fixed" — not exactly
+# "a bug caught", which is impossible to determine programmatically, but
+# a directional proxy. The design doc accepts this tradeoff.
+#
+# Output: one JSON object per PLATFORM on stdout (multiple workflows on
+# the same platform are aggregated), e.g.
+#   {"platform":"kotlin","pr_time":5,"main":1,"total":6}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+SINCE="$(iso_days_ago 30)"
+
+# Returns 1 (true) if the diff between two SHAs in a repo contains a file
+# outside .github/, else 0. Empty diff (same SHA) returns 0.
+diff_touches_non_github() {
+  local repo="$1" base="$2" head="$3"
+  if [[ "$base" == "$head" ]]; then
+    echo 0
+    return
+  fi
+  local files
+  files=$(gh api "repos/$repo/compare/$base...$head" --jq '.files[].filename' 2>/dev/null || true)
+  if [[ -z "$files" ]]; then
+    echo 0
+    return
+  fi
+  if echo "$files" | grep -vq '^\.github/'; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+# Walks <created_at>\t<head_sha>\t<conclusion> rows on stdin (must be sorted
+# by created_at ascending) and counts failure→success transitions that
+# touch non-.github files between the two SHAs. Prints the catch count.
+count_red_green_transitions() {
+  local repo="$1"
+  local catches=0 failed_sha=""
+  while IFS=$'\t' read -r _ sha conc; do
+    case "$conc" in
+      failure) failed_sha="$sha" ;;
+      success)
+        if [[ -n "$failed_sha" ]]; then
+          if [[ "$(diff_touches_non_github "$repo" "$failed_sha" "$sha")" == 1 ]]; then
+            catches=$((catches + 1))
+          fi
+          failed_sha=""
+        fi
+        ;;
+    esac
+  done
+  echo "$catches"
+}
+
+# Resolve <created_at>\t<head_sha>\t<conclusion> per run, applying
+# job_pattern when set. Emits sorted-by-created-at on stdout.
+runs_with_conclusion() {
+  local repo="$1" runs_json="$2" job_pattern="$3"
+  if [[ -z "$runs_json" ]]; then
+    return
+  fi
+  if [[ -z "$job_pattern" ]]; then
+    printf '%s\n' "$runs_json" | jq -r '
+      [.created_at, .head_sha, (.conclusion // "null")] | @tsv
+    ' | sort
+  else
+    # When filtering by job, we need to look up each run's jobs and pick
+    # the matching one's conclusion. resolve_conclusions returns
+    # <run_id>\t<conclusion>. Join back to created_at + head_sha by id.
+    local resolved
+    resolved=$(printf '%s\n' "$runs_json" | resolve_conclusions "$repo" "$job_pattern")
+    printf '%s\n' "$runs_json" | jq -r '[.id, .created_at, .head_sha] | @tsv' \
+      | while IFS=$'\t' read -r id ca sha; do
+          local conc
+          conc=$(echo "$resolved" | awk -F'\t' -v id="$id" '$1 == id { print $2; exit }')
+          [[ -n "$conc" ]] && printf '%s\t%s\t%s\n' "$ca" "$sha" "$conc"
+        done | sort
+  fi
+}
+
+count_main_catches() {
+  local repo="$1" workflow_path="$2" job_pattern="${3:-}" branch="${4:-}"
+  local query="created=>=$SINCE"
+  [[ -n "$branch" ]] && query="branch=$branch&$query"
+  local runs_json
+  runs_json=$(fetch_runs "$repo" "$workflow_path" "$query")
+  runs_with_conclusion "$repo" "$runs_json" "$job_pattern" \
+    | count_red_green_transitions "$repo"
+}
+
+count_pr_time_catches() {
+  local repo="$1" workflow_path="$2" job_pattern="${3:-}"
+  local since_date="${SINCE%T*}"
+
+  # Merged PRs in window.
+  local prs
+  prs=$(gh api "search/issues?q=repo:$repo+is:pr+is:merged+merged:>=$since_date&per_page=100" \
+    --jq '.items[].number' 2>/dev/null || true)
+
+  local total=0
+  for pr_number in $prs; do
+    local head_ref
+    head_ref=$(gh api "repos/$repo/pulls/$pr_number" --jq '.head.ref' 2>/dev/null || true)
+    [[ -z "$head_ref" ]] && continue
+
+    local pr_runs_json
+    pr_runs_json=$(fetch_runs "$repo" "$workflow_path" "event=pull_request&branch=$head_ref&created=>=$SINCE")
+    [[ -z "$pr_runs_json" ]] && continue
+
+    # Only one catch per PR (don't double-count multiple red→green flips).
+    local catches
+    catches=$(runs_with_conclusion "$repo" "$pr_runs_json" "$job_pattern" \
+      | count_red_green_transitions "$repo")
+    [[ "$catches" -gt 0 ]] && total=$((total + 1))
+  done
+  echo "$total"
+}
+
+# Emit one JSONL row per workflow entry, then aggregate by platform at the
+# end via jq. Avoids associative arrays (bash 3.2 / macOS doesn't support
+# them; CI Ubuntu does but the script should be testable locally).
+per_workflow=$(mktemp)
+trap 'rm -f "$per_workflow"' EXIT
+
+while IFS= read -r entry; do
+  repo=$(jq -r '.repo' <<<"$entry")
+  workflow_path=$(jq -r '.workflow_path' <<<"$entry")
+  job_pattern=$(jq -r '.job_pattern // ""' <<<"$entry")
+  branch=$(jq -r '.branch // ""' <<<"$entry")
+  platform=$(jq -r '.platform' <<<"$entry")
+
+  pr_catches=$(count_pr_time_catches "$repo" "$workflow_path" "$job_pattern" 2>/dev/null || echo 0)
+  main_catches=$(count_main_catches "$repo" "$workflow_path" "$job_pattern" "$branch" 2>/dev/null || echo 0)
+  # Defend against count_* emitting a non-numeric or empty value when a
+  # sub-pipeline trips set -e: coerce to integer.
+  [[ "$pr_catches" =~ ^[0-9]+$ ]] || pr_catches=0
+  [[ "$main_catches" =~ ^[0-9]+$ ]] || main_catches=0
+
+  jq -nc \
+    --arg platform "$platform" \
+    --argjson pr_time "$pr_catches" \
+    --argjson main "$main_catches" \
+    '{platform: $platform, pr_time: $pr_time, main: $main}' >> "$per_workflow"
+done < <(read_workflows)
+
+# Aggregate by platform, preserve config order via index.
+jq -sc '
+  reduce .[] as $row ({platforms: [], by: {}};
+    if (.by[$row.platform] == null)
+    then .platforms += [$row.platform]
+       | .by[$row.platform] = {pr_time: 0, main: 0}
+    else . end
+    | .by[$row.platform].pr_time += $row.pr_time
+    | .by[$row.platform].main    += $row.main
+  )
+  | .platforms[] as $p
+  | {platform: $p,
+     pr_time: .by[$p].pr_time,
+     main:    .by[$p].main,
+     total:   (.by[$p].pr_time + .by[$p].main)}
+' "$per_workflow"

--- a/metrics/scripts/kpi_flake_rate.sh
+++ b/metrics/scripts/kpi_flake_rate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Compute 7-day flake rate per workflow.
+#
+# Flake rate = (failures that passed on rerun) / (all failures)
+#
+# A "failure that passed on rerun" is a workflow run whose final
+# conclusion is success but run_attempt > 1 — i.e. an earlier attempt
+# on the same SHA failed and a re-run flipped it green. This is the
+# definition the design doc commits to. Note: in-job retries (like the
+# wrapper inside pay-core's sub-validate.yml's Maestro job) are
+# invisible at this level, so they aren't counted as flakes.
+#
+# Output: one JSON object per workflow on stdout, e.g.
+#   {"platform":"kotlin","label":"kotlin","recovered":1,"failed":2,"total_failures":3,"rate":33.33}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+SINCE="$(iso_days_ago 7)"
+
+while IFS= read -r entry; do
+  repo=$(jq -r '.repo' <<<"$entry")
+  workflow_path=$(jq -r '.workflow_path' <<<"$entry")
+  job_pattern=$(jq -r '.job_pattern // ""' <<<"$entry")
+  branch=$(jq -r '.branch // ""' <<<"$entry")
+  label=$(jq -r '.label' <<<"$entry")
+  platform=$(jq -r '.platform' <<<"$entry")
+
+  query="created=>=$SINCE"
+  [[ -n "$branch" ]] && query="branch=$branch&$query"
+
+  # For each run in window, we need both run_attempt and the resolved
+  # conclusion. We can't fold this into resolve_conclusions without
+  # losing the attempt count, so we re-pair.
+  runs_json=$(fetch_runs "$repo" "$workflow_path" "$query")
+  if [[ -z "$runs_json" ]]; then
+    jq -nc --arg p "$platform" --arg l "$label" '{platform:$p, label:$l, recovered:0, failed:0, total_failures:0, rate:0.0}'
+    continue
+  fi
+
+  # attempts: <run_id>\t<run_attempt>
+  attempts=$(printf '%s\n' "$runs_json" | jq -r '"\(.id)\t\(.run_attempt)"')
+  # conclusions: <run_id>\t<conclusion>
+  conclusions=$(printf '%s\n' "$runs_json" | resolve_conclusions "$repo" "$job_pattern")
+
+  # Join on run_id, count recovered vs failed.
+  recovered=0
+  failed=0
+  while IFS=$'\t' read -r run_id conclusion; do
+    attempt=$(echo "$attempts" | awk -F'\t' -v id="$run_id" '$1 == id { print $2; exit }')
+    case "$conclusion:$attempt" in
+      success:1) : ;;          # clean pass
+      success:*) recovered=$((recovered + 1)) ;;  # green after rerun = flake recovered
+      failure:*) failed=$((failed + 1)) ;;        # red even after any reruns
+      *)         : ;;          # cancelled / skipped / startup_failure — ignore
+    esac
+  done <<<"$conclusions"
+
+  total=$((recovered + failed))
+  if [[ $total -gt 0 ]]; then
+    rate=$(awk -v r="$recovered" -v t="$total" 'BEGIN { printf "%.2f", (r/t) * 100 }')
+  else
+    rate="0.00"
+  fi
+
+  jq -nc \
+    --arg platform "$platform" \
+    --arg label "$label" \
+    --argjson recovered "$recovered" \
+    --argjson failed "$failed" \
+    --argjson total "$total" \
+    --argjson rate "$rate" \
+    '{platform: $platform, label: $label, recovered: $recovered, failed: $failed, total_failures: $total, rate: $rate}'
+done < <(read_workflows)

--- a/metrics/scripts/kpi_p95_feedback.sh
+++ b/metrics/scripts/kpi_p95_feedback.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Compute 7-day P95 PR feedback time per workflow.
+#
+# Definition: P95 of (run.updated_at - run.created_at) over PR-time runs
+# (event = pull_request) in the last 7 days. updated_at is the latest
+# state change — for a completed run that's when it finished.
+#
+# Output: one JSON object per workflow on stdout, e.g.
+#   {"platform":"kotlin","label":"kotlin","p95_seconds":1320,"p95_minutes":22,"count":18}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+SINCE="$(iso_days_ago 7)"
+
+while IFS= read -r entry; do
+  repo=$(jq -r '.repo' <<<"$entry")
+  workflow_path=$(jq -r '.workflow_path' <<<"$entry")
+  label=$(jq -r '.label' <<<"$entry")
+  platform=$(jq -r '.platform' <<<"$entry")
+
+  # Filter to runs that actually completed with a real outcome — `cancelled`
+  # / `skipped` / `startup_failure` etc. inflate P95 because the run sits
+  # queued (or limps along) for hours before the final state change, which
+  # is what updated_at captures.
+  durations=$(fetch_runs "$repo" "$workflow_path" "event=pull_request&created=>=$SINCE" \
+    | jq -r 'select(.status == "completed" and (.conclusion == "success" or .conclusion == "failure")) |
+             ((.updated_at | fromdateiso8601) - (.created_at | fromdateiso8601))')
+
+  if [[ -z "$durations" ]]; then
+    jq -nc --arg p "$platform" --arg l "$label" \
+      '{platform:$p, label:$l, p95_seconds:0, p95_minutes:0, count:0}'
+    continue
+  fi
+
+  count=$(echo "$durations" | wc -l | tr -d ' ')
+  p95_seconds=$(echo "$durations" | percentile 95)
+  p95_minutes=$(awk -v s="$p95_seconds" 'BEGIN { printf "%d", s / 60 }')
+
+  jq -nc \
+    --arg platform "$platform" \
+    --arg label "$label" \
+    --argjson p95_seconds "$p95_seconds" \
+    --argjson p95_minutes "$p95_minutes" \
+    --argjson count "$count" \
+    '{platform: $platform, label: $label, p95_seconds: $p95_seconds, p95_minutes: $p95_minutes, count: $count}'
+done < <(read_workflows)

--- a/metrics/scripts/kpi_pass_rate.sh
+++ b/metrics/scripts/kpi_pass_rate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compute 7-day pass rate per workflow on main.
+#
+# Pass rate = success / (success + failure)
+# Runs with conclusion neither success nor failure (cancelled, skipped,
+# startup_failure, etc.) are excluded — they aren't signals about test health.
+#
+# Output: one JSON object per workflow on stdout, e.g.
+#   {"platform":"kotlin","label":"kotlin","success":26,"failure":1,"total":27,"rate":96.30}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+SINCE="$(iso_days_ago 7)"
+
+while IFS= read -r entry; do
+  repo=$(jq -r '.repo' <<<"$entry")
+  workflow_path=$(jq -r '.workflow_path' <<<"$entry")
+  job_pattern=$(jq -r '.job_pattern // ""' <<<"$entry")
+  branch=$(jq -r '.branch // ""' <<<"$entry")
+  label=$(jq -r '.label' <<<"$entry")
+  platform=$(jq -r '.platform' <<<"$entry")
+
+  query="created=>=$SINCE"
+  [[ -n "$branch" ]] && query="branch=$branch&$query"
+
+  conclusions=$(fetch_runs "$repo" "$workflow_path" "$query" \
+    | resolve_conclusions "$repo" "$job_pattern" \
+    | awk -F'\t' '{print $2}')
+
+  success=$(echo "$conclusions" | grep -c '^success$' || true)
+  failure=$(echo "$conclusions" | grep -c '^failure$' || true)
+  total=$((success + failure))
+
+  if [[ $total -gt 0 ]]; then
+    rate=$(awk -v s="$success" -v t="$total" 'BEGIN { printf "%.2f", (s/t) * 100 }')
+  else
+    rate="0.00"
+  fi
+
+  jq -nc \
+    --arg platform "$platform" \
+    --arg label "$label" \
+    --argjson success "$success" \
+    --argjson failure "$failure" \
+    --argjson total "$total" \
+    --argjson rate "$rate" \
+    '{platform: $platform, label: $label, success: $success, failure: $failure, total: $total, rate: $rate}'
+done < <(read_workflows)

--- a/metrics/scripts/lib.sh
+++ b/metrics/scripts/lib.sh
@@ -66,9 +66,15 @@ resolve_conclusions() {
     if [[ -z "$job_pattern" ]]; then
       jq -r '"\(.id)\t\(.conclusion // "null")"' <<<"$run"
     else
+      # Pipe through jq separately so we can pass the pattern via --arg.
+      # Interpolating into --jq's expression string risks breaking the
+      # filter (silently — swallowed by 2>/dev/null) on any future
+      # job_pattern containing ", \, or jq metachars.
       local conclusion
-      conclusion=$(gh api "repos/$repo/actions/runs/$run_id/jobs" \
-        --jq ".jobs[] | select(.name | test(\"$job_pattern\")) | .conclusion" 2>/dev/null | head -1 || true)
+      conclusion=$(gh api "repos/$repo/actions/runs/$run_id/jobs" 2>/dev/null \
+        | jq -r --arg pat "$job_pattern" \
+          '.jobs[] | select(.name | test($pat)) | .conclusion' \
+        | head -1 || true)
       if [[ -n "$conclusion" ]]; then
         printf '%s\t%s\n' "$run_id" "$conclusion"
       fi

--- a/metrics/scripts/lib.sh
+++ b/metrics/scripts/lib.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Shared helpers for metrics/scripts/kpi_*.sh.
+#
+# Requires: gh CLI (authenticated), jq, date (GNU coreutils — macOS users
+# need `gawk` and `gdate` via brew, but CI runs on Ubuntu).
+#
+# All public functions print to stdout. Errors go to stderr and exit non-zero.
+
+set -euo pipefail
+
+CONFIG_PATH="${CONFIG_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/config/workflows.json}"
+
+# ISO-8601 timestamp N days ago, e.g. iso_days_ago 7 -> 2026-05-27T11:23:45Z
+# Works on both GNU date (Ubuntu CI) and BSD date (macOS local testing).
+iso_days_ago() {
+  if date -u -d "$1 days ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; then
+    return 0
+  fi
+  date -u -v "-$1d" +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# Read all workflow entries from config as one-line JSON objects (jq -c).
+read_workflows() {
+  jq -c '.workflows[]' "$CONFIG_PATH"
+}
+
+# Page through GitHub workflow_runs for (repo, workflow_path), filtered by
+# the query string the caller provides (e.g. "branch=main&event=push&created=...").
+# Echoes one JSON workflow_run per line. Stops after 5 pages (500 runs) to
+# bound API usage; the 7d / 30d windows for our workflows fit comfortably.
+fetch_runs() {
+  local repo="$1" workflow_path="$2" query="$3"
+  # API takes the workflow filename (or numeric id), not the full path.
+  local workflow_file="${workflow_path##*/}"
+  local page=1
+  while [[ $page -le 5 ]]; do
+    local response
+    # `gh api --jq` pretty-prints by default; re-emit as compact one-per-line
+    # so downstream consumers can read line-by-line.
+    response=$(gh api "repos/$repo/actions/workflows/$workflow_file/runs?per_page=100&page=$page&$query" \
+      --jq '.workflow_runs[]' 2>/dev/null | jq -c '.' || true)
+    if [[ -z "$response" ]]; then
+      break
+    fi
+    printf '%s\n' "$response"
+    local count
+    count=$(printf '%s\n' "$response" | wc -l)
+    if [[ $count -lt 100 ]]; then
+      break
+    fi
+    page=$((page + 1))
+  done
+}
+
+# For each run, resolve the effective conclusion: either the workflow run's
+# top-level conclusion, or — when job_pattern is set in the config entry —
+# the conclusion of the (first) job whose name matches the regex.
+#
+# Reads run JSON lines on stdin; writes lines of `<run_id>\t<conclusion>` to
+# stdout. Skips runs with no matching job (job_pattern set but no match).
+resolve_conclusions() {
+  local repo="$1" job_pattern="${2:-}"
+  while IFS= read -r run; do
+    local run_id
+    run_id=$(jq -r '.id' <<<"$run")
+    if [[ -z "$job_pattern" ]]; then
+      jq -r '"\(.id)\t\(.conclusion // "null")"' <<<"$run"
+    else
+      local conclusion
+      conclusion=$(gh api "repos/$repo/actions/runs/$run_id/jobs" \
+        --jq ".jobs[] | select(.name | test(\"$job_pattern\")) | .conclusion" 2>/dev/null | head -1 || true)
+      if [[ -n "$conclusion" ]]; then
+        printf '%s\t%s\n' "$run_id" "$conclusion"
+      fi
+    fi
+  done
+}
+
+# Compute the Nth percentile of a list of numbers on stdin (one per line).
+# Usage: echo -e "10\n20\n30\n40" | percentile 95
+# Uses sort(1) instead of awk's gawk-only asort() for portability.
+percentile() {
+  local p="$1"
+  sort -n | awk -v p="$p" '
+    { a[NR] = $1 }
+    END {
+      if (NR == 0) { print "0"; exit }
+      idx = int((p / 100) * NR + 0.999999)
+      if (idx < 1) idx = 1
+      if (idx > NR) idx = NR
+      print a[idx]
+    }
+  '
+}
+
+# Pretty-print a KPI value as a single Slack-table cell with status icon.
+# Usage: kpi_cell <numeric_value> <threshold_op> <threshold> <suffix>
+#   e.g. kpi_cell 96.5 ">=" 95 "%" -> "✅ 96.5%"
+# Operators supported: >=, <, <=
+kpi_cell() {
+  local value="$1" op="$2" threshold="$3" suffix="${4:-}"
+  local pass
+  case "$op" in
+    ">=") pass=$(awk -v v="$value" -v t="$threshold" 'BEGIN { print (v >= t) ? 1 : 0 }') ;;
+    "<")  pass=$(awk -v v="$value" -v t="$threshold" 'BEGIN { print (v <  t) ? 1 : 0 }') ;;
+    "<=") pass=$(awk -v v="$value" -v t="$threshold" 'BEGIN { print (v <= t) ? 1 : 0 }') ;;
+    *) echo "kpi_cell: unknown op $op" >&2; return 1 ;;
+  esac
+  if [[ "$pass" == 1 ]]; then
+    echo "✅ ${value}${suffix}"
+    return
+  fi
+  # Soft-yellow zone: within 10% of threshold. Otherwise red.
+  local within_soft
+  within_soft=$(awk -v v="$value" -v t="$threshold" -v op="$op" 'BEGIN {
+    if (op == ">=") { print (v >= t * 0.9) ? 1 : 0 }
+    else            { print (v <= t * 1.5) ? 1 : 0 }
+  }')
+  if [[ "$within_soft" == 1 ]]; then
+    echo "🟡 ${value}${suffix}"
+  else
+    echo "🔴 ${value}${suffix}"
+  fi
+}

--- a/metrics/scripts/post_to_slack.sh
+++ b/metrics/scripts/post_to_slack.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Assemble the daily Slack message from the four KPI outputs and POST it
+# to the webhook. Emits attention-line + threshold-breach alerts when the
+# numbers warrant.
+#
+# Inputs (file paths, one JSON object per line, format from kpi_*.sh):
+#   PASS_FILE       — pass rate per workflow
+#   FLAKE_FILE      — flake rate per workflow
+#   P95_FILE        — P95 feedback per workflow
+#   CATCHES_FILE    — bug catches per platform
+#   YESTERDAY_PASS  — yesterday's pass rate per workflow (optional; for week-over-week deltas and "2 consecutive days <90%" alert)
+#
+# Env: SLACK_KPI_WEBHOOK_URL is required at runtime.
+
+set -euo pipefail
+
+PASS_FILE="${PASS_FILE:?missing}"
+FLAKE_FILE="${FLAKE_FILE:?missing}"
+P95_FILE="${P95_FILE:?missing}"
+CATCHES_FILE="${CATCHES_FILE:?missing}"
+YESTERDAY_PASS="${YESTERDAY_PASS:-/dev/null}"
+# When DRY_RUN=1, print the message to stdout instead of POSTing. Useful
+# for local debugging and the workflow echoes the dry-run output so the
+# run log is self-contained.
+DRY_RUN="${DRY_RUN:-0}"
+if [[ "$DRY_RUN" != "1" ]]; then
+  SLACK_WEBHOOK="${SLACK_KPI_WEBHOOK_URL:?missing SLACK_KPI_WEBHOOK_URL}"
+fi
+TODAY="${TODAY:-$(date -u +%Y-%m-%d)}"
+
+# Targets per the design doc.
+PASS_TARGET=95
+FLAKE_TARGET=5
+P95_TARGET_MIN=30
+PASS_ALERT=90
+FLAKE_ALERT=10
+P95_ALERT_MIN=45
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# Build a row for one workflow. Looks up flake + p95 by label.
+build_row() {
+  local pass_entry="$1"
+  local label rate total
+  label=$(jq -r '.label' <<<"$pass_entry")
+  rate=$(jq -r '.rate' <<<"$pass_entry")
+  total=$(jq -r '.total' <<<"$pass_entry")
+
+  local flake_rate flake_total p95_min p95_count
+  flake_rate=$(jq -r --arg l "$label" 'select(.label == $l) | .rate' "$FLAKE_FILE" | head -1)
+  flake_total=$(jq -r --arg l "$label" 'select(.label == $l) | .total_failures' "$FLAKE_FILE" | head -1)
+  p95_min=$(jq -r --arg l "$label" 'select(.label == $l) | .p95_minutes' "$P95_FILE" | head -1)
+  p95_count=$(jq -r --arg l "$label" 'select(.label == $l) | .count' "$P95_FILE" | head -1)
+  flake_rate="${flake_rate:-0}"
+  p95_min="${p95_min:-0}"
+
+  local pass_cell flake_cell p95_cell
+  if [[ "${total:-0}" == "0" ]]; then
+    pass_cell="—"
+  else
+    pass_cell=$(kpi_cell "$rate" ">=" "$PASS_TARGET" "%")
+  fi
+  if [[ "${flake_total:-0}" == "0" ]]; then
+    flake_cell="—"
+  else
+    flake_cell=$(kpi_cell "$flake_rate" "<" "$FLAKE_TARGET" "%")
+  fi
+  if [[ "${p95_count:-0}" == "0" ]]; then
+    p95_cell="—"
+  else
+    p95_cell=$(kpi_cell "$p95_min" "<" "$P95_TARGET_MIN" "m")
+  fi
+
+  # Fixed-width formatting for Slack code block.
+  printf '%-22s  %-10s  %-10s  %s\n' "$label" "$pass_cell" "$flake_cell" "$p95_cell"
+}
+
+# Attention line: list workflows where any metric is in red/yellow zone.
+build_attention_line() {
+  local notes=()
+  while IFS= read -r pass_entry; do
+    local label rate total
+    label=$(jq -r '.label' <<<"$pass_entry")
+    rate=$(jq -r '.rate' <<<"$pass_entry")
+    total=$(jq -r '.total' <<<"$pass_entry")
+    local flake_rate flake_total p95_min p95_count
+    flake_rate=$(jq -r --arg l "$label" 'select(.label == $l) | .rate' "$FLAKE_FILE" | head -1)
+    flake_total=$(jq -r --arg l "$label" 'select(.label == $l) | .total_failures' "$FLAKE_FILE" | head -1)
+    p95_min=$(jq -r --arg l "$label" 'select(.label == $l) | .p95_minutes' "$P95_FILE" | head -1)
+    p95_count=$(jq -r --arg l "$label" 'select(.label == $l) | .count' "$P95_FILE" | head -1)
+    flake_rate="${flake_rate:-0}"
+    p95_min="${p95_min:-0}"
+
+    local issues=()
+    if [[ "${total:-0}" != "0" ]]; then
+      awk -v v="$rate" -v t="$PASS_TARGET" 'BEGIN { exit (v < t) ? 0 : 1 }' && issues+=("pass $rate%")
+    fi
+    if [[ "${flake_total:-0}" != "0" ]]; then
+      awk -v v="$flake_rate" -v t="$FLAKE_TARGET" 'BEGIN { exit (v >= t) ? 0 : 1 }' && issues+=("flake $flake_rate%")
+    fi
+    if [[ "${p95_count:-0}" != "0" ]]; then
+      awk -v v="$p95_min" -v t="$P95_TARGET_MIN" 'BEGIN { exit (v >= t) ? 0 : 1 }' && issues+=("P95 ${p95_min}m")
+    fi
+
+    if (( ${#issues[@]} > 0 )); then
+      local joined
+      joined=$(printf ', %s' "${issues[@]}")
+      notes+=("$label ${joined:2}")
+    fi
+  done < "$PASS_FILE"
+
+  if (( ${#notes[@]} > 0 )); then
+    local joined
+    joined=$(printf '; %s' "${notes[@]}")
+    echo "⚠️ Attention: ${joined:2}"
+  fi
+}
+
+# Bar chart for bug catches.
+build_catches_section() {
+  local total
+  total=$(jq -s 'map(.total) | add // 0' "$CATCHES_FILE")
+  local pr_total main_total
+  pr_total=$(jq -s 'map(.pr_time) | add // 0' "$CATCHES_FILE")
+  main_total=$(jq -s 'map(.main) | add // 0' "$CATCHES_FILE")
+
+  local avg_days
+  if [[ $total -gt 0 ]]; then
+    avg_days=$(awk -v t="$total" 'BEGIN { printf "%.1f", 30 / t }')
+    echo "🐛 Bug catches — last 30d: $total total (avg every $avg_days days)"
+  else
+    echo "🐛 Bug catches — last 30d: 0 total"
+  fi
+  echo "   PR-time catches:  $pr_total   •   Main-branch catches:  $main_total"
+  echo ""
+
+  while IFS= read -r entry; do
+    local platform total_p bar
+    platform=$(jq -r '.platform' <<<"$entry")
+    total_p=$(jq -r '.total' <<<"$entry")
+    if [[ $total_p -gt 0 ]]; then
+      bar=$(printf '▓%.0s' $(seq 1 "$total_p"))
+    else
+      bar=""
+    fi
+    printf '   %-8s %s %d\n' "$platform" "$bar" "$total_p"
+  done < "$CATCHES_FILE"
+}
+
+# Threshold-breach alerts.
+build_alerts() {
+  local alerts=()
+  while IFS= read -r pass_entry; do
+    local label rate
+    label=$(jq -r '.label' <<<"$pass_entry")
+    rate=$(jq -r '.rate' <<<"$pass_entry")
+    local flake_rate p95_min
+    flake_rate=$(jq -r --arg l "$label" 'select(.label == $l) | .rate' "$FLAKE_FILE" | head -1)
+    p95_min=$(jq -r --arg l "$label" 'select(.label == $l) | .p95_minutes' "$P95_FILE" | head -1)
+    flake_rate="${flake_rate:-0.00}"
+    p95_min="${p95_min:-0}"
+
+    # Pass rate < 90% for 2 consecutive days
+    if awk -v v="$rate" -v t="$PASS_ALERT" 'BEGIN { exit (v < t) ? 0 : 1 }'; then
+      local yesterday_rate=""
+      if [[ -s "$YESTERDAY_PASS" ]]; then
+        yesterday_rate=$(jq -r --arg l "$label" 'select(.label == $l) | .rate' "$YESTERDAY_PASS" | head -1)
+      fi
+      if [[ -n "$yesterday_rate" ]] && awk -v v="$yesterday_rate" -v t="$PASS_ALERT" 'BEGIN { exit (v < t) ? 0 : 1 }'; then
+        alerts+=("🚨 \`$label\` pass rate <$PASS_ALERT% for 2 consecutive days (today $rate%, yesterday $yesterday_rate%)")
+      fi
+    fi
+    if awk -v v="$flake_rate" -v t="$FLAKE_ALERT" 'BEGIN { exit (v > t) ? 0 : 1 }'; then
+      alerts+=("🚨 \`$label\` flake rate $flake_rate% exceeds $FLAKE_ALERT%")
+    fi
+    if awk -v v="$p95_min" -v t="$P95_ALERT_MIN" 'BEGIN { exit (v > t) ? 0 : 1 }'; then
+      alerts+=("🚨 \`$label\` P95 feedback ${p95_min}m exceeds ${P95_ALERT_MIN}m")
+    fi
+  done < "$PASS_FILE"
+
+  if (( ${#alerts[@]} > 0 )); then
+    printf '%s\n' "${alerts[@]}"
+  fi
+}
+
+# Assemble the message body.
+body=$(cat <<EOF
+📊 Maestro E2E KPIs — $TODAY
+
+$(printf '%-22s  %-10s  %-10s  %s\n' "" "Pass rate" "Flake rate" "P95 PR feedback")
+$(printf '%-22s  %-10s  %-10s  %s\n' "" "(7d, main)" "(7d)" "(7d)")
+$(printf -- '-%.0s' {1..72})
+$(while IFS= read -r entry; do build_row "$entry"; done < "$PASS_FILE")
+$(printf -- '-%.0s' {1..72})
+🎯 targets              ≥${PASS_TARGET}%       <${FLAKE_TARGET}%         <${P95_TARGET_MIN}m
+
+$(build_catches_section)
+EOF
+)
+
+attention=$(build_attention_line || true)
+if [[ -n "$attention" ]]; then
+  body="$body
+
+$attention"
+fi
+
+# Daily summary as a code block.
+daily="\`\`\`$body\`\`\`"
+alerts=$(build_alerts || true)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "--- daily summary ---"
+  echo "$daily"
+  if [[ -n "$alerts" ]]; then
+    echo
+    echo "--- threshold alerts ---"
+    echo "$alerts"
+  fi
+  exit 0
+fi
+
+payload=$(jq -nc --arg text "$daily" '{text: $text}')
+curl -fsS -X POST -H "Content-Type: application/json" \
+  -d "$payload" "$SLACK_WEBHOOK" > /dev/null
+
+if [[ -n "$alerts" ]]; then
+  alert_payload=$(jq -nc --arg text "$alerts" '{text: $text}')
+  curl -fsS -X POST -H "Content-Type: application/json" \
+    -d "$alert_payload" "$SLACK_WEBHOOK" > /dev/null
+fi

--- a/metrics/scripts/post_to_slack.sh
+++ b/metrics/scripts/post_to_slack.sh
@@ -25,6 +25,10 @@ YESTERDAY_PASS="${YESTERDAY_PASS:-/dev/null}"
 DRY_RUN="${DRY_RUN:-0}"
 if [[ "$DRY_RUN" != "1" ]]; then
   SLACK_WEBHOOK="${SLACK_KPI_WEBHOOK_URL:?missing SLACK_KPI_WEBHOOK_URL}"
+  # Auto-masking covers the secret value as ${{ secrets.* }} resolved it,
+  # but doesn't follow into derived shell variables. Re-mask both forms
+  # so a stray `set -x` (or ACTIONS_STEP_DEBUG) can't leak the URL.
+  echo "::add-mask::$SLACK_WEBHOOK"
 fi
 TODAY="${TODAY:-$(date -u +%Y-%m-%d)}"
 
@@ -222,12 +226,19 @@ if [[ "$DRY_RUN" == "1" ]]; then
   exit 0
 fi
 
+# Write the webhook URL to a curl config file so it stays out of argv
+# (visible under set -x / ACTIONS_STEP_DEBUG / /proc/<pid>/cmdline).
+_curl_cfg=$(mktemp)
+trap 'rm -f "$_curl_cfg"' EXIT
+printf 'url = "%s"\n' "$SLACK_WEBHOOK" > "$_curl_cfg"
+chmod 600 "$_curl_cfg"
+
 payload=$(jq -nc --arg text "$daily" '{text: $text}')
 curl -fsS -X POST -H "Content-Type: application/json" \
-  -d "$payload" "$SLACK_WEBHOOK" > /dev/null
+  -d "$payload" --config "$_curl_cfg" > /dev/null
 
 if [[ -n "$alerts" ]]; then
   alert_payload=$(jq -nc --arg text "$alerts" '{text: $text}')
   curl -fsS -X POST -H "Content-Type: application/json" \
-    -d "$alert_payload" "$SLACK_WEBHOOK" > /dev/null
+    -d "$alert_payload" --config "$_curl_cfg" > /dev/null
 fi


### PR DESCRIPTION
Implements the [WalletConnect Pay Maestro E2E KPIs measurement plan](https://walletconnect.notion.site/WalletConnect-Pay-Maestro-E2E-KPIs-measurement-plan-35d3a661771e81f1a78cec0019f8afbd).

One nightly GHA cron at 09:00 UTC reads workflow-run history across the 5 SDK / backend repos (6 workflows total), computes four KPIs, and posts a fixed-width summary + threshold-breach alerts to `#e2e-kpis`. No external infra.

## What's in the PR

```
metrics/
├── config/workflows.json         9 fields per entry, 6 entries total
├── scripts/
│   ├── lib.sh                    gh wrapper, jq helpers, percentile,
│   │                             KPI cell formatter
│   ├── kpi_pass_rate.sh          success / (success + failure), 7d
│   ├── kpi_flake_rate.sh         run_attempt > 1 succeeded, 7d
│   ├── kpi_p95_feedback.sh       P95(updated_at − created_at) on
│   │                             PR-time runs, 7d
│   ├── kpi_bug_catches.sh        red→green pairs whose diff touches
│   │                             non-`.github/` files, 30d
│   └── post_to_slack.sh          assembles message + POSTs to webhook
│                                 (DRY_RUN=1 prints to stdout)
└── README.md                     setup, config schema, known limits

.github/workflows/maestro-kpi-aggregate.yml
                                  cron `0 9 * * *` + workflow_dispatch;
                                  persists yesterday's pass rates as
                                  an artifact for "<90% × 2 days" alert
```

960 lines net, mostly shell + jq.

## Output (real data, rendered today via `DRY_RUN=1` locally)

````
📊 Maestro E2E KPIs — 2026-06-04

                        Pass rate   Flake rate  P95 PR feedback
                        (7d, main)  (7d)        (7d)
────────────────────────────────────────────────────────────────────────
kotlin                  🟡 90.00%  ✅ 0.00%   ✅ 16m
swift                   🔴 33.33%  ✅ 0.00%   🔴 1737m
flutter                 🔴 33.33%  🔴 33.33%  🔴 79m
rn                      🔴 37.19%  ✅ 0.00%   🔴 99m
core (PR)               ✅ 100.00% —          ✅ 27m
core (CD)               🔴 66.67%  ✅ 0.00%   —
────────────────────────────────────────────────────────────────────────
🎯 targets              ≥95%       <5%         <30m

🐛 Bug catches — last 30d: 28 total (avg every 1.1 days)
   PR-time catches:  15   •   Main-branch catches:  13

   kotlin   ▓▓▓▓▓ 5
   swift    ▓▓▓ 3
   flutter  ▓▓▓▓ 4
   rn       ▓▓▓▓▓▓▓ 7
   core     ▓▓▓▓▓▓▓▓▓ 9

⚠️ Attention: kotlin pass 90.00%; swift pass 33.33%, P95 1737m; flutter pass 33.33%, flake 33.33%, P95 79m; rn pass 37.19%, P95 99m; core (CD) pass 66.67%
````

Separate threshold-breach message posts when any of `pass <90%×2d`, `flake >10%`, `P95 >45m` trips.

`—` shows when a workflow has no data for that KPI (e.g. PR-only SDK workflows have no main-branch push runs; `event_release.yml` has no PR runs so P95 is N/A there). Cleaner than misleading "0m ✅".

## Things worth flagging to reviewers

1. **The doc lists workflows under `WalletConnect/*` for kotlin/swift/flutter — they're actually under `reown-com/*`.** Confirmed via the workflows API; doc is stale. The config reflects reality.

2. **pay-core's "Validate" entry isn't directly addressable.** `sub-validate.yml` is reusable; the Maestro job runs nested inside `event_release.yml`'s run. The config uses `event_release.yml` as the run-level entry + `job_pattern: "^CD / Validate Staging / WX Pay E2E Maestro - android - staging$"` to pull the right job. The `job_pattern` field is also generally useful when one job of many is in scope.

3. **SDK repos don't fire E2E on push.** Kotlin's `ci_e2e_pay_tests.yml` triggers are `pull_request` + `workflow_dispatch` only — no `push`. The design doc says "pass rate on main only" but that would be structurally zero. Config has no `branch` field for those entries, so pass rate covers all CI runs. README documents the deviation from the doc.

4. **`branch=main` filter applies where it can.** RN + pay-core PR-time + pay-core CD all have `branch: "main"` in config.

5. **Bug-catch heuristic noise.** Already documented in the doc and README. We filter out diffs that only touch `.github/` to suppress workflow-churn false positives (e.g. pay-core PR #630's stability commits don't count).

6. **Personal-PAT bus factor.** v1 uses a PAT owned by one person. Migrate to a GitHub App or service account before this becomes load-bearing.

## Pre-merge manual setup (Jakub owns)

1. Create `#e2e-kpis` Slack channel + incoming webhook
2. Provision PAT (fine-grained, scoped to the 5 tracked repos) — `actions:read` + `metadata:read`
3. Set org-level secrets on `WalletConnect/actions`:
   - `KPI_GITHUB_PAT` = the PAT
   - `SLACK_KPI_WEBHOOK_URL` = the webhook
4. Merge this PR
5. `gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions` to smoke-test before the first cron fires

## Local validation done

End-to-end run against real APIs (visible numbers in the screenshot above are from `2026-06-04` against the live workflows). Bash 3.2 compatible — local macOS dev works, CI Ubuntu works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)