### PR TITLE
fix(maestro): retry iOS universal-link open until pay-merchant-info is visible

### DIFF
--- a/maestro/pay-tests/.maestro/flows/pay_open_via_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/flows/pay_open_via_deeplink.yaml
@@ -1,12 +1,20 @@
 appId: ${APP_ID}
 ---
-# Shared flow: Open payment URL via deep link
+# Shared flow: Open payment URL via deep link, retrying until the app opens.
 # Requires: ${output.gateway_url} to be set by a prior runScript step
 
-# Stop app then open via deeplink so openLink is the launch intent.
-- stopApp:
-    appId: ${APP_ID}
-- openLink:
-    link: ${output.gateway_url}
-    autoVerify: true
-    browser: false
+# iOS sometimes routes the Universal Link to Safari instead of the app. If the
+# merchant-info wait times out, retry re-runs the block, re-issuing openLink.
+- retry:
+    maxRetries: 3
+    commands:
+      - stopApp:
+          appId: ${APP_ID}
+      - openLink:
+          link: ${output.gateway_url}
+          autoVerify: true
+          browser: false
+      - extendedWaitUntil:
+          visible:
+            id: "pay-merchant-info"
+          timeout: 45000

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -17,25 +17,9 @@ tags:
 
 - startRecording: "Pay - Single Option No KYC (Universal Link)"
 
-# Open wallet via deep link with payment URL
+# Open wallet via deep link. Shared flow retries until pay-merchant-info is visible.
 - runFlow:
     file: flows/pay_open_via_deeplink.yaml
-
-# Wait for payment options to load.
-#
-# Higher timeout than the paste-URL flows because this is the only
-# cold-start path in the suite: pay_open_via_deeplink.yaml does
-# stopApp + openLink, so the wallet's first sign of life is the OS
-# routing the Android intent into a fresh process — ActivityManager
-# fork, Hermes init, RN bridge, deep-link router, then the API call.
-# On a contended CI emulator the new process can take 20-30s to
-# attach (sometimes failing with `Process ... failed to attach` and
-# requiring re-fork), which left the 30s budget consistently tight
-# (pay-core run 26570588681).
-- extendedWaitUntil:
-    visible:
-      id: "pay-merchant-info"
-    timeout: 60000
 
 # Single option auto-selects — go straight to review screen
 


### PR DESCRIPTION
## Context

The `pay_single_option_nokyc_deeplink` Maestro test is flaky on iOS. It opens a `https://pay.walletconnect.com` Universal Link via `openLink` (`autoVerify: true`, `browser: false`). Intermittently iOS routes the link to **Safari instead of the wallet app** (a known Universal Link quirk — once the OS "breaks out" to the browser it can keep doing so). When that happens the app never launches, the `pay-merchant-info` wait times out, and the whole test fails.

Previously the open step had **no retry** — just a single `stopApp` + `openLink` followed by one long wait.

## Change

- **`flows/pay_open_via_deeplink.yaml`** — wrap `stopApp` + `openLink` + a `pay-merchant-info` wait in Maestro's `retry` block (`maxRetries: 3`, 45s/attempt). If the wait times out (Safari case), the whole block re-runs and re-issues the link. It only returns once the app is genuinely on the pay screen; if all attempts fail it still fails loudly.
- **`pay_single_option_nokyc_deeplink.yaml`** — remove the now-redundant 60s `pay-merchant-info` wait, since the shared opener guarantees it on return.

## Notes / caveats

- `retry` is available in the Maestro 1.39+ line this repo installs (latest via the official installer). If ever pinned to an older version lacking `retry`, fall back to a bounded `repeat: { while: { notVisible } }` + trailing `assertVisible`.
- Per-attempt timeout is 45s (down from 60s); the old 60s was tuned for Android emulator re-fork, and we now get up to 4 attempts.
- This retries the *open*, fixing the common single-bad-route case. If iOS persists routing to Safari for a session, `stopApp` + re-`openLink` may still land in Safari; if residual flakiness remains we may need to explicitly close/background Safari between attempts.

## Verification

Not run locally — `maestro test --include-tags pay` needs the iOS simulator and a Universal-Link-configured wallet build (this action just copies the flows into the consumer repo). Validated by inspection against the existing flow structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)