### PR TITLE
metrics: tighten Slack output — drop bug catches, add window dates + counts

### DIFF
--- a/.github/workflows/maestro-kpi-aggregate.yml
+++ b/.github/workflows/maestro-kpi-aggregate.yml
@@ -62,22 +62,21 @@ jobs:
       - name: Compute P95 feedback (7d, PR)
         run: bash metrics/scripts/kpi_p95_feedback.sh > p95.jsonl
 
-      - name: Compute bug catches (30d)
-        run: bash metrics/scripts/kpi_bug_catches.sh > catches.jsonl
+      # Bug-catches KPI (kpi_bug_catches.sh) is kept in-tree for a later
+      # iteration but not rendered in Slack yet — the heuristic produces
+      # numbers that are too noisy to act on without more analysis.
 
       - name: Echo computed KPIs (for run-log debuggability)
         run: |
           echo "--- pass.jsonl ---"; cat pass.jsonl
           echo "--- flake.jsonl ---"; cat flake.jsonl
           echo "--- p95.jsonl ---";  cat p95.jsonl
-          echo "--- catches.jsonl ---"; cat catches.jsonl
 
       - name: Post to Slack
         env:
           PASS_FILE: pass.jsonl
           FLAKE_FILE: flake.jsonl
           P95_FILE: p95.jsonl
-          CATCHES_FILE: catches.jsonl
           YESTERDAY_PASS: yesterday/pass.jsonl
         run: bash metrics/scripts/post_to_slack.sh
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -69,31 +69,26 @@ Heuristic, not exact. Known biases:
 Daily 09:00 UTC post to `#wx-e2e-kpis`:
 
 ```
-📊 Maestro E2E KPIs — 2026-06-03
+📊 Maestro E2E KPIs — 7d window: 2026-06-01 → 2026-06-08
 
-                       Pass rate   Flake rate  P95 PR feedback
-                       (7d, main)  (7d)        (7d)
-────────────────────────────────────────────────────────────
-kotlin                  ✅ 98.2%   ✅ 2.1%     ✅ 22m
-swift                   🟡 91.5%   🟡 8.3%     🟡 34m
-flutter                 ✅ 99.0%   ✅ 1.2%     ✅ 18m
-rn                      ✅ 96.8%   ✅ 3.4%     ✅ 28m
-core (PR)               ✅ 97.1%   ✅ 4.0%     ✅ 25m
-core (CD)               ✅ 96.0%   ✅ 0.0%     ✅ 28m
-────────────────────────────────────────────────────────────
-🎯 targets              ≥95%       <5%         <30m
+              Pass rate               Flake rate              P95 PR feedback
+              (success/total)         (recovered/failures)    (n = sample size)
+──────────────────────────────────────────────────────────────────────────────
+kotlin        ✅ 100.00% (4/4)        — (no failures)         ✅ 15m (n=4)
+swift         🔴 57.14% (4/7)         ✅ 0.00% (0/3)          ✅ 16m (n=5)
+flutter       🔴 60.00% (3/5)         🔴 50.00% (2/4)         🔴 79m (n=5)
+rn            🔴 67.23% (80/119)      ✅ 0.00% (0/39)         🔴 46m (n=15)
+core (PR)     ✅ 96.77% (30/31)       ✅ 0.00% (0/1)          ✅ 27m (n=167)
+core (CD)     🔴 68.42% (13/19)       🔴 25.00% (2/8)         — (no PR runs)
+──────────────────────────────────────────────────────────────────────────────
+🎯 targets    ≥95%                    <5%                     <30m
 
-🐛 Bug catches — last 30d: 14 total (avg every 2.1 days)
-   PR-time catches:  11   •   Main-branch catches:  3
-
-   kotlin   ▓▓▓▓▓ 5
-   swift    ▓ 1
-   flutter  ▓▓ 2
-   rn       ▓▓▓ 3
-   core     ▓▓▓ 3
-
-⚠️ Attention: swift pass 91.5%, flake 8.3%, P95 34m
+⚠️ Attention: swift pass 57.14%; flutter pass 60.00%, flake 50.00%, P95 79m; …
 ```
+
+> Bug-catches KPI (kpi_bug_catches.sh) is kept in-tree for a future
+> iteration but currently not surfaced — heuristic is too noisy to act
+> on without more triage.
 
 Separate threshold-breach alerts post when:
 

--- a/metrics/scripts/post_to_slack.sh
+++ b/metrics/scripts/post_to_slack.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Assemble the daily Slack message from the four KPI outputs and POST it
+# Assemble the daily Slack message from the three KPI outputs and POST it
 # to the webhook. Emits attention-line + threshold-breach alerts when the
 # numbers warrant.
 #
@@ -7,8 +7,8 @@
 #   PASS_FILE       — pass rate per workflow
 #   FLAKE_FILE      — flake rate per workflow
 #   P95_FILE        — P95 feedback per workflow
-#   CATCHES_FILE    — bug catches per platform
-#   YESTERDAY_PASS  — yesterday's pass rate per workflow (optional; for week-over-week deltas and "2 consecutive days <90%" alert)
+#   YESTERDAY_PASS  — yesterday's pass rate per workflow (optional; for
+#                     "2 consecutive days <90%" alert)
 #
 # Env: SLACK_KPI_WEBHOOK_URL is required at runtime.
 
@@ -17,20 +17,18 @@ set -euo pipefail
 PASS_FILE="${PASS_FILE:?missing}"
 FLAKE_FILE="${FLAKE_FILE:?missing}"
 P95_FILE="${P95_FILE:?missing}"
-CATCHES_FILE="${CATCHES_FILE:?missing}"
 YESTERDAY_PASS="${YESTERDAY_PASS:-/dev/null}"
-# When DRY_RUN=1, print the message to stdout instead of POSTing. Useful
-# for local debugging and the workflow echoes the dry-run output so the
-# run log is self-contained.
 DRY_RUN="${DRY_RUN:-0}"
 if [[ "$DRY_RUN" != "1" ]]; then
   SLACK_WEBHOOK="${SLACK_KPI_WEBHOOK_URL:?missing SLACK_KPI_WEBHOOK_URL}"
-  # Auto-masking covers the secret value as ${{ secrets.* }} resolved it,
-  # but doesn't follow into derived shell variables. Re-mask both forms
-  # so a stray `set -x` (or ACTIONS_STEP_DEBUG) can't leak the URL.
   echo "::add-mask::$SLACK_WEBHOOK"
 fi
-TODAY="${TODAY:-$(date -u +%Y-%m-%d)}"
+
+# Window: same 7d the kpi_*.sh scripts use (lib.sh::iso_days_ago 7).
+# Compute fresh here so the Slack header always reflects the same
+# interval the scripts queried.
+WINDOW_END="${TODAY:-$(date -u +%Y-%m-%d)}"
+WINDOW_START="${WINDOW_START:-$(date -u -d "7 days ago" +%Y-%m-%d 2>/dev/null || date -u -v -7d +%Y-%m-%d)}"
 
 # Targets per the design doc.
 PASS_TARGET=95
@@ -47,38 +45,43 @@ source "$SCRIPT_DIR/lib.sh"
 # Build a row for one workflow. Looks up flake + p95 by label.
 build_row() {
   local pass_entry="$1"
-  local label rate total
+  local label rate success total
   label=$(jq -r '.label' <<<"$pass_entry")
   rate=$(jq -r '.rate' <<<"$pass_entry")
+  success=$(jq -r '.success' <<<"$pass_entry")
   total=$(jq -r '.total' <<<"$pass_entry")
 
-  local flake_rate flake_total p95_min p95_count
+  local flake_rate flake_recovered flake_total p95_min p95_count
   flake_rate=$(jq -r --arg l "$label" 'select(.label == $l) | .rate' "$FLAKE_FILE" | head -1)
+  flake_recovered=$(jq -r --arg l "$label" 'select(.label == $l) | .recovered' "$FLAKE_FILE" | head -1)
   flake_total=$(jq -r --arg l "$label" 'select(.label == $l) | .total_failures' "$FLAKE_FILE" | head -1)
   p95_min=$(jq -r --arg l "$label" 'select(.label == $l) | .p95_minutes' "$P95_FILE" | head -1)
   p95_count=$(jq -r --arg l "$label" 'select(.label == $l) | .count' "$P95_FILE" | head -1)
   flake_rate="${flake_rate:-0}"
+  flake_recovered="${flake_recovered:-0}"
+  flake_total="${flake_total:-0}"
   p95_min="${p95_min:-0}"
+  p95_count="${p95_count:-0}"
 
   local pass_cell flake_cell p95_cell
   if [[ "${total:-0}" == "0" ]]; then
-    pass_cell="—"
+    pass_cell="— (no runs)"
   else
-    pass_cell=$(kpi_cell "$rate" ">=" "$PASS_TARGET" "%")
+    pass_cell="$(kpi_cell "$rate" ">=" "$PASS_TARGET" "%") ($success/$total)"
   fi
   if [[ "${flake_total:-0}" == "0" ]]; then
-    flake_cell="—"
+    flake_cell="— (no failures)"
   else
-    flake_cell=$(kpi_cell "$flake_rate" "<" "$FLAKE_TARGET" "%")
+    flake_cell="$(kpi_cell "$flake_rate" "<" "$FLAKE_TARGET" "%") ($flake_recovered/$flake_total)"
   fi
   if [[ "${p95_count:-0}" == "0" ]]; then
-    p95_cell="—"
+    p95_cell="— (no PR runs)"
   else
-    p95_cell=$(kpi_cell "$p95_min" "<" "$P95_TARGET_MIN" "m")
+    p95_cell="$(kpi_cell "$p95_min" "<" "$P95_TARGET_MIN" "m") (n=$p95_count)"
   fi
 
-  # Fixed-width formatting for Slack code block.
-  printf '%-22s  %-10s  %-10s  %s\n' "$label" "$pass_cell" "$flake_cell" "$p95_cell"
+  # Wider columns to fit the counts.
+  printf '%-12s  %-22s  %-22s  %s\n' "$label" "$pass_cell" "$flake_cell" "$p95_cell"
 }
 
 # Attention line: list workflows where any metric is in red/yellow zone.
@@ -122,37 +125,6 @@ build_attention_line() {
   fi
 }
 
-# Bar chart for bug catches.
-build_catches_section() {
-  local total
-  total=$(jq -s 'map(.total) | add // 0' "$CATCHES_FILE")
-  local pr_total main_total
-  pr_total=$(jq -s 'map(.pr_time) | add // 0' "$CATCHES_FILE")
-  main_total=$(jq -s 'map(.main) | add // 0' "$CATCHES_FILE")
-
-  local avg_days
-  if [[ $total -gt 0 ]]; then
-    avg_days=$(awk -v t="$total" 'BEGIN { printf "%.1f", 30 / t }')
-    echo "🐛 Bug catches — last 30d: $total total (avg every $avg_days days)"
-  else
-    echo "🐛 Bug catches — last 30d: 0 total"
-  fi
-  echo "   PR-time catches:  $pr_total   •   Main-branch catches:  $main_total"
-  echo ""
-
-  while IFS= read -r entry; do
-    local platform total_p bar
-    platform=$(jq -r '.platform' <<<"$entry")
-    total_p=$(jq -r '.total' <<<"$entry")
-    if [[ $total_p -gt 0 ]]; then
-      bar=$(printf '▓%.0s' $(seq 1 "$total_p"))
-    else
-      bar=""
-    fi
-    printf '   %-8s %s %d\n' "$platform" "$bar" "$total_p"
-  done < "$CATCHES_FILE"
-}
-
 # Threshold-breach alerts.
 build_alerts() {
   local alerts=()
@@ -166,7 +138,6 @@ build_alerts() {
     flake_rate="${flake_rate:-0.00}"
     p95_min="${p95_min:-0}"
 
-    # Pass rate < 90% for 2 consecutive days
     if awk -v v="$rate" -v t="$PASS_ALERT" 'BEGIN { exit (v < t) ? 0 : 1 }'; then
       local yesterday_rate=""
       if [[ -s "$YESTERDAY_PASS" ]]; then
@@ -191,16 +162,14 @@ build_alerts() {
 
 # Assemble the message body.
 body=$(cat <<EOF
-📊 Maestro E2E KPIs — $TODAY
+📊 Maestro E2E KPIs — 7d window: $WINDOW_START → $WINDOW_END
 
-$(printf '%-22s  %-10s  %-10s  %s\n' "" "Pass rate" "Flake rate" "P95 PR feedback")
-$(printf '%-22s  %-10s  %-10s  %s\n' "" "(7d, main)" "(7d)" "(7d)")
-$(printf -- '-%.0s' {1..72})
+$(printf '%-12s  %-22s  %-22s  %s\n' "" "Pass rate" "Flake rate" "P95 PR feedback")
+$(printf '%-12s  %-22s  %-22s  %s\n' "" "(success/total)" "(recovered/failures)" "(n = sample size)")
+$(printf -- '-%.0s' {1..78})
 $(while IFS= read -r entry; do build_row "$entry"; done < "$PASS_FILE")
-$(printf -- '-%.0s' {1..72})
-🎯 targets              ≥${PASS_TARGET}%       <${FLAKE_TARGET}%         <${P95_TARGET_MIN}m
-
-$(build_catches_section)
+$(printf -- '-%.0s' {1..78})
+🎯 targets    ≥${PASS_TARGET}%                  <${FLAKE_TARGET}%                   <${P95_TARGET_MIN}m
 EOF
 )
 
@@ -211,7 +180,6 @@ if [[ -n "$attention" ]]; then
 $attention"
 fi
 
-# Daily summary as a code block.
 daily="\`\`\`$body\`\`\`"
 alerts=$(build_alerts || true)
 
@@ -226,8 +194,7 @@ if [[ "$DRY_RUN" == "1" ]]; then
   exit 0
 fi
 
-# Write the webhook URL to a curl config file so it stays out of argv
-# (visible under set -x / ACTIONS_STEP_DEBUG / /proc/<pid>/cmdline).
+# Webhook URL via curl --config file to keep it out of argv.
 _curl_cfg=$(mktemp)
 trap 'rm -f "$_curl_cfg"' EXIT
 printf 'url = "%s"\n' "$SLACK_WEBHOOK" > "$_curl_cfg"


### PR DESCRIPTION
Follow-up to #91 based on team feedback after the first cron run.

## Changes

1. **Bug catches section removed.** The heuristic counts red→green pairs touching non-`.github/` files, which mixes real fixes with test-infra changes. Too noisy to act on without deeper triage. `kpi_bug_catches.sh` stays in-tree for a v2 iteration; the workflow simply doesn't invoke it.

2. **Window dates in the header.** Readers couldn't tell at a glance what 7-day interval the numbers covered.
   - before: `📊 Maestro E2E KPIs — 2026-06-08`
   - after:  `📊 Maestro E2E KPIs — 7d window: 2026-06-01 → 2026-06-08`

3. **Raw counts inline with each KPI cell.** Without absolute volume the percentages can mislead (`100% pass` from 1/1 looks the same as 50/50).
   - Pass: `100.00% (4/4)` — `(success/total)`
   - Flake: `50.00% (2/4)` — `(recovered/failures)`
   - P95: `16m (n=7)` — `(n = sample size)`
   - No-data: `— (no runs|failures|PR runs)` — explicit about why

## Rendered output (real data, dry-run)

```
📊 Maestro E2E KPIs — 7d window: 2026-06-01 → 2026-06-08

              Pass rate               Flake rate              P95 PR feedback
              (success/total)         (recovered/failures)    (n = sample size)
──────────────────────────────────────────────────────────────────────────────
kotlin        ✅ 100.00% (4/4)        — (no failures)         ✅ 15m (n=4)
swift         🔴 57.14% (4/7)         ✅ 0.00% (0/3)          ✅ 16m (n=5)
flutter       🔴 60.00% (3/5)         🔴 50.00% (2/4)         🔴 79m (n=5)
rn            🔴 67.23% (80/119)      ✅ 0.00% (0/39)         🔴 46m (n=15)
core (PR)     ✅ 96.77% (30/31)       ✅ 0.00% (0/1)          ✅ 27m (n=167)
core (CD)     🔴 68.42% (13/19)       🔴 25.00% (2/8)         — (no PR runs)
──────────────────────────────────────────────────────────────────────────────
🎯 targets    ≥95%                    <5%                     <30m
```

Threshold-breach alerts unchanged.

## Diff scope

3 files, +53 / −92. Net negative — removing the bug-catches code path simplifies the script and shortens the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)