### PR TITLE
chore(maestro): bump end-to-end success + cold-start timeouts

### DIFF
--- a/maestro/pay-tests/.maestro/flows/pay_confirm_and_verify.yaml
+++ b/maestro/pay-tests/.maestro/flows/pay_confirm_and_verify.yaml
@@ -10,11 +10,22 @@ appId: ${APP_ID}
 - tapOn:
     id: "pay-button-pay"
 
-# Wait for success screen (generous timeout for on-chain confirmation)
+# Wait for success screen. Covers the end-to-end settlement path:
+# wallet broadcasts, pay-core relayer queues + commits the batch, on-chain
+# confirmation, pay-core gateway flips status to `succeeded`, wallet poll
+# observes it, success screen renders.
+#
+# 60s headroom (was 30s). Pay-core CD runs against deployed staging where
+# the same chain is shared with the rest of staging traffic; under contention
+# the gateway can take 35-50s to surface `succeeded`. The 30s budget was
+# leaving the three end-to-end flows (Single Option No KYC, Single Option
+# No KYC (Deep Link), Double Scan Same Payment) stuck on "Processing your
+# payment..." in clustered failure windows. See pay-core soak data on
+# 2026-06-05 and 2026-06-08 for the dominant failure pattern.
 - extendedWaitUntil:
     visible:
       id: "pay-result-success-icon"
-    timeout: 30000
+    timeout: 60000
 
 # Tap "Got it!" button
 - tapOn:

--- a/maestro/pay-tests/.maestro/flows/pay_open_and_paste_url.yaml
+++ b/maestro/pay-tests/.maestro/flows/pay_open_and_paste_url.yaml
@@ -26,7 +26,11 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "button-scan"
-    timeout: 60000
+    # Bumped 60s → 90s after pay-core CD on 2026-06-08/09 hit a few
+    # 60s timeouts on Multiple Options No KYC's first launchApp. The
+    # cold-start path itself is unchanged; the previous budget was just
+    # consistently cutting it close on contended emulators.
+    timeout: 90000
 
 # Tap scan button to open scanner options modal
 - tapOn:


### PR DESCRIPTION
## Summary

Two `extendedWaitUntil` timeouts bumped in shared flows, driven by pay-core CD soak data:

| File | Step | Before | After |
|---|---|---|---|
| `pay_confirm_and_verify.yaml` | `pay-result-success-icon` | 30s | **60s** |
| `pay_open_and_paste_url.yaml` | `button-scan` | 60s | **90s** |

## Why

Pay-core's `core (CD)` Maestro KPI for week 2026-06-04 → 2026-06-11: pass rate **58.82% (10/17)**, flake **12.50% (1/8)**. Investigation of the 7 failures showed two clusters that account for all of them.

### Cluster A — settlement delay (5 of 7 failures)

Three end-to-end flows fail in lockstep:

- `Single Option No KYC` — `pay-result-success-icon is visible`
- `Single Option No KYC (Deep Link)` — same
- `Double Scan Same Payment` — same

Screenshots at the timeout show the wallet stuck on **"Processing your payment…"**. Logcat is quiet — no crashes, no `PayError`, no React Native exceptions. The wallet tapped Pay, kicked the request to pay-core's staging gateway, and is patiently polling for `status=succeeded` — but the gateway doesn't flip within the 30s budget. Settlement is just slow on contended staging (Base mainnet RPC + relayer queue shared with the rest of the env).

These are the only three flows that actually go end-to-end through settlement. All other flows in the suite reach a terminal screen (cancelled / expired / KYC webview / multi-option-info-required) without needing on-chain confirmation, which is why the rest stay green during the same windows.

Failures cluster tightly in time (e.g. 2026-06-05 evening UTC, 2026-06-08 noon UTC) which is the signature of transient infrastructure contention rather than a permanent bug. The 30s budget had no headroom for a slow settlement — bumping to 60s absorbs the contention without masking real product bugs (a payment that genuinely fails will still surface as `pay-result-success-icon` never showing).

### Cluster B — cold-start race (2 of 7 failures)

Same pattern we already addressed in [#89](https://github.com/WalletConnect/actions/pull/89). `Multiple Options No KYC` (and once `Multiple Options with KYC`) failed at exactly **1m 5s** on `button-scan is visible` — `extendedWaitUntil` 60s + ~5s overhead. The post-`clearState` `launchApp` is still occasionally bursting past 60s on contended emulators. 90s removes the residual.

### Why the in-job retry didn't catch these

All 7 failures hit on **attempt 2** — i.e. attempt 1 also failed. The retry is good at masking random per-run jitter but not at re-rolling environmental conditions: while staging is slow or while the emulator is degraded, both attempts hit the same wall.

## Trade-off

Other flows are unaffected. `extendedWaitUntil` exits as soon as the target element renders, so on a healthy run the new budgets are never reached. The change is one-directional: tolerate slow runs that would have failed before, without changing behaviour on fast runs.

## Test plan

- [ ] reown-com/react-native-examples `ci_e2e_walletkit.yaml` hourly schedule stays green
- [ ] pay-core CD `core (CD)` pass rate trends back to ≥95% across the next ~10 CD runs (the soak window for confidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)