### PR TITLE
Tool-agnostic Pay flows + per-flow recording runner

### DIFF
--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -13,8 +13,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Cancel from KYC Webview"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -84,5 +82,3 @@ tags:
 # Dismiss
 - tapOn:
     id: "pay-button-result-action-cancelled"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_cancel_from_review.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_review.yaml
@@ -12,8 +12,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Cancel from Review Screen"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -59,5 +57,3 @@ tags:
 # Dismiss
 - tapOn:
     id: "pay-button-result-action-cancelled"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_cancelled.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancelled.yaml
@@ -19,8 +19,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Load a cancelled payment"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -42,5 +40,3 @@ tags:
 # Dismiss the error dialog
 - tapOn:
     id: "pay-button-result-action-cancelled"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_double_scan.yaml
+++ b/maestro/pay-tests/.maestro/pay_double_scan.yaml
@@ -12,8 +12,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Double Scan Same Payment"
-
 # === First scan: complete the payment normally ===
 
 # Open wallet, paste payment URL
@@ -31,10 +29,7 @@ tags:
     visible:
       id: "pay-button-pay"
     timeout: 10000
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # Tap Pay, verify success, tap "Got it!"
 - runFlow:
@@ -61,5 +56,3 @@ tags:
 # Dismiss the error dialog
 - tapOn:
     id: "pay-button-result-action-generic"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_expired_link.yaml
+++ b/maestro/pay-tests/.maestro/pay_expired_link.yaml
@@ -9,8 +9,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Use an expired payment link"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -32,5 +30,3 @@ tags:
 # Dismiss the error dialog
 - tapOn:
     id: "pay-button-result-action-expired"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_insufficient_funds.yaml
+++ b/maestro/pay-tests/.maestro/pay_insufficient_funds.yaml
@@ -13,8 +13,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Insufficient Funds"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -36,5 +34,3 @@ tags:
 # Dismiss the error dialog
 - tapOn:
     id: "pay-button-result-action-insufficient_funds"
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_back_navigation.yaml
@@ -12,8 +12,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Check Back and Close Buttons in KYC Webview"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -64,5 +62,3 @@ tags:
     visible:
       id: "button-scan"
     timeout: 10000
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -13,8 +13,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Multiple Payment Options with KYC"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -74,13 +72,8 @@ tags:
     id: "pay-review-token-${maestro.copiedText}"
 
 # Verify pay button shows the correct amount
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # Tap Pay, verify success
 - runFlow:
     file: flows/pay_confirm_and_verify.yaml
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc.yaml
@@ -12,8 +12,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Multiple Payment Options without KYC"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -48,13 +46,8 @@ tags:
     id: "pay-review-token-${maestro.copiedText}"
 
 # Verify pay button shows the correct amount
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # Tap Pay, verify success
 - runFlow:
     file: flows/pay_confirm_and_verify.yaml
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -12,8 +12,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - Single Payment Option without KYC"
-
 # Open wallet, paste payment URL
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -31,10 +29,7 @@ tags:
     visible:
       id: "pay-button-pay"
     timeout: 10000
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # Tap Pay, verify success
 - runFlow:
@@ -45,5 +40,3 @@ tags:
     visible:
       id: "button-scan"
     timeout: 10000
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc_deeplink.yaml
@@ -15,8 +15,6 @@ tags:
 # openLink to Safari. The cold start is already handled by stopApp + openLink
 # in flows/pay_open_via_deeplink.yaml.
 
-- startRecording: "Pay - Single Option No KYC (Universal Link)"
-
 # Open wallet via deep link. Shared flow retries until pay-merchant-info is visible.
 - runFlow:
     file: flows/pay_open_via_deeplink.yaml
@@ -28,13 +26,8 @@ tags:
     visible:
       id: "pay-button-pay"
     timeout: 10000
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # Tap Pay, verify success
 - runFlow:
     file: flows/pay_confirm_and_verify.yaml
-
-- stopRecording

--- a/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
+++ b/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
@@ -13,8 +13,6 @@ tags:
 
 - clearState
 
-- startRecording: "Pay - USDT on Polygon"
-
 # Open wallet, paste payment URL, wait for options
 - runFlow:
     file: flows/pay_open_and_paste_url.yaml
@@ -34,10 +32,7 @@ tags:
 - assertVisible:
     id: "pay-review-token-polygon"
 
-- copyTextFrom:
-    id: "pay-button-pay"
-- assertTrue:
-    condition: "${maestro.copiedText.startsWith('Pay $')}"
+- assertVisible: "Pay \\$.*"
 
 # USDT on Polygon is a Permit2 token: the wallet sends approve() then payment().
 - tapOn:
@@ -64,5 +59,3 @@ tags:
     visible:
       id: "button-scan"
     timeout: 10000
-
-- stopRecording

--- a/maestro/pay-tests/action.yml
+++ b/maestro/pay-tests/action.yml
@@ -34,6 +34,10 @@ runs:
         # Copy scripts
         cp "$ACTION_DIR"/.maestro/scripts/*.js "$TARGET_DIR/scripts/"
 
+        # Copy shared runner scripts (e.g. run-pay-flows.sh)
+        cp "$ACTION_DIR"/scripts/*.sh "$TARGET_DIR/scripts/" 2>/dev/null || true
+        chmod +x "$TARGET_DIR"/scripts/*.sh 2>/dev/null || true
+
         echo "Copied Maestro Pay test flows to $TARGET_DIR"
         ls -la "$TARGET_DIR"
 

--- a/maestro/pay-tests/scripts/run-pay-flows.sh
+++ b/maestro/pay-tests/scripts/run-pay-flows.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Run the WalletConnect Pay E2E flows one-per-invocation with native screen
+# recording, keeping a video only when a flow fails. Tool-agnostic: drives
+# `maestro` by default, or `ennio` (RN-only fast local runner) via RUNNER=ennio.
+#
+# Why per-flow: native recorders (simctl io recordVideo / adb screenrecord) have
+# no concept of "flows" — they record continuously. Wrapping each flow gives one
+# video per flow instead of one giant video for the whole suite.
+#
+# Required env:
+#   PLATFORM        ios | android
+#   DEVICE_ID       iOS simulator UDID (ios) — ignored on android (uses adb)
+#   FLOWS_DIR       directory containing pay_*.yaml (default: .maestro)
+#   OUT_DIR         artifact dir for logs + kept videos (default: maestro-artifacts)
+#   APP_ID, WPAY_*  passed through to the flows
+# Optional env:
+#   RUNNER          maestro (default) | ennio
+#   MAESTRO_BIN     path to maestro (default: $HOME/.maestro/bin/maestro)
+#   INCLUDE_TAGS    maestro --include-tags value (default: pay; ignored for ennio)
+#   EXCLUDE_TAGS    maestro --exclude-tags value (optional; ignored for ennio)
+#   DEBUG_OUTPUT    maestro --debug-output dir (optional; ignored for ennio)
+#   ATTEMPTS        per-flow retries (default: 2)
+#   FLOW_GLOB       glob of flows to run (default: $FLOWS_DIR/pay_*.yaml)
+#
+set -uo pipefail
+PLATFORM="${PLATFORM:?set PLATFORM=ios|android}"
+RUNNER="${RUNNER:-maestro}"
+FLOWS_DIR="${FLOWS_DIR:-.maestro}"
+OUT_DIR="${OUT_DIR:-maestro-artifacts}"
+MAESTRO_BIN="${MAESTRO_BIN:-$HOME/.maestro/bin/maestro}"
+INCLUDE_TAGS="${INCLUDE_TAGS:-pay}"
+EXCLUDE_TAGS="${EXCLUDE_TAGS:-}"
+DEBUG_OUTPUT="${DEBUG_OUTPUT:-}"
+ATTEMPTS="${ATTEMPTS:-2}"
+FLOW_GLOB="${FLOW_GLOB:-$FLOWS_DIR/pay_*.yaml}"
+mkdir -p "$OUT_DIR"
+
+env_args=(--env APP_ID="${APP_ID:-}")
+for v in WPAY_CUSTOMER_KEY_SINGLE_NOKYC WPAY_MERCHANT_ID_SINGLE_NOKYC \
+         WPAY_CUSTOMER_KEY_MULTI_NOKYC WPAY_MERCHANT_ID_MULTI_NOKYC \
+         WPAY_CUSTOMER_KEY_MULTI_KYC WPAY_MERCHANT_ID_MULTI_KYC \
+         WPAY_PAY_API_URL WPAY_EXPIRED_GATEWAY_URL; do
+  env_args+=(--env "$v=${!v:-}")
+done
+
+start_rec() { # $1=video path -> echoes recorder pid
+  if [ "$PLATFORM" = ios ]; then
+    xcrun simctl io "$DEVICE_ID" recordVideo --codec h264 --force "$1" >/dev/null 2>&1 & echo $!
+  else
+    # adb screenrecord runs on-device; 180s cap is safe for a single pay flow
+    adb shell screenrecord --bit-rate 4000000 "/sdcard/$(basename "$1")" >/dev/null 2>&1 & echo $!
+  fi
+}
+stop_rec() { # $1=pid $2=video path
+  kill -INT "$1" 2>/dev/null; wait "$1" 2>/dev/null
+  if [ "$PLATFORM" = android ]; then
+    sleep 1; adb pull "/sdcard/$(basename "$2")" "$2" >/dev/null 2>&1 || true
+    adb shell rm -f "/sdcard/$(basename "$2")" >/dev/null 2>&1 || true
+  fi
+}
+
+overall=0
+shopt -s nullglob
+for flow in $FLOW_GLOB; do
+  name=$(basename "$flow" .yaml)
+  video="$OUT_DIR/${name}.mp4"
+  log="$OUT_DIR/${name}.log"
+  rec=$(start_rec "$video")
+  rc=1
+  for a in $(seq 1 "$ATTEMPTS"); do
+    echo "=== $RUNNER $name (attempt $a/$ATTEMPTS) ==="
+    if [ "$RUNNER" = ennio ]; then
+      ennio test "$flow" >>"$log" 2>&1
+    else
+      "$MAESTRO_BIN" test "${env_args[@]}" --include-tags "$INCLUDE_TAGS" \
+        ${EXCLUDE_TAGS:+--exclude-tags "$EXCLUDE_TAGS"} \
+        ${DEBUG_OUTPUT:+--debug-output "$DEBUG_OUTPUT"} \
+        --test-output-dir "$OUT_DIR" "$flow" >>"$log" 2>&1
+    fi
+    rc=$?; [ $rc -eq 0 ] && break
+  done
+  stop_rec "$rec" "$video"
+  if [ $rc -eq 0 ]; then rm -f "$video"; echo "PASS  $name"; else overall=1; echo "FAIL  $name (kept $video)"; fi
+done
+exit $overall


### PR DESCRIPTION
## What

Makes the shared WalletConnect Pay E2E flows run **unmodified on both Maestro (all platforms) and [Ennio](https://github.com/enzomanuelmangano/ennio)** (an RN-only fast local runner), without forking the flow set, and moves video capture to a tool-agnostic per-flow runner.

### Flow changes (all 12 root `pay_*.yaml`)
- **Remove `startRecording`/`stopRecording`** — video-only commands that Ennio hard-errors on. Video now comes from the runner below (captures the full screen, including native↔web transitions).
- **Replace** `copyTextFrom: pay-button-pay` + `assertTrue: ${maestro.copiedText.startsWith('Pay $')}` **with** `assertVisible: "Pay \$.*"` (regex). Equivalent coverage; works on both engines; drops a Maestro-runner-specific construct.
- Kept `pay-review-token-${maestro.copiedText}` substitutions — Ennio supports `${maestro.copiedText}` *substitution*; only the `assertTrue` *method-expression* eval differs between engines.

### New: `scripts/run-pay-flows.sh`
Runs flows **one-per-invocation** with native screen recording (`simctl io recordVideo` / `adb screenrecord`), keeping a video **only when a flow fails** — one video per flow instead of one giant suite video. `RUNNER=maestro` (default) or `RUNNER=ennio`.

## Why
Native recorders have no concept of "flows"; they record continuously. Per-flow wrapping gives per-flow videos. Removing the in-flow recording commands is what unblocks Ennio, and the runner gives the videos back — for both tools.

## Validation (local, rn_cli_wallet RN 0.85.3, iPhone 16 sim)
Same files, both runners, all green:

| Flow | Maestro | Ennio |
|---|---|---|
| pay_single_option_nokyc | ✅ | ✅ |
| pay_multiple_options_nokyc | ✅ | ✅ |
| pay_cancelled | ✅ | ✅ |
| pay_insufficient_funds | ✅ | ✅ |
| pay_expired_link | ✅ | ✅ |

Keep-on-failure verified (failing flow retains video + log; passing flow discards video).

## Notes / open questions
- Universal-link/deeplink flows (`*_deeplink`, `pay_open_via_deeplink`) are unchanged and were **not** run under Ennio locally — they need a signed app for associated-domains (works in CI with AASA priming, not on a bare local sim).
- The consumer CI (reown-com/react-native-examples) needs a companion PR to call `run-pay-flows.sh` (per-flow loop) instead of the single suite `maestro test .maestro/`, otherwise per-flow videos are lost when `startRecording` goes away. Draft incoming.
- **Ennio is RN-only** (dylib injection + React-commit observation) — it does not drive the Swift/Kotlin/Flutter wallets. Maestro stays the universal runner; Ennio is an additive faster *local* runner for the RN wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)