### PR TITLE
fix(metrics): P95 PR feedback measures job wall-clock, not run wall-clock

### DIFF
--- a/metrics/scripts/kpi_p95_feedback.sh
+++ b/metrics/scripts/kpi_p95_feedback.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Compute 7-day P95 PR feedback time per workflow.
 #
-# Definition: P95 of (run.updated_at - run.created_at) over PR-time runs
-# (event = pull_request) in the last 7 days. updated_at is the latest
-# state change — for a completed run that's when it finished.
+# Definition: P95 of (run.updated_at - run.run_started_at) over PR-time
+# runs (event = pull_request) in the last 7 days. We use run_started_at,
+# NOT created_at, because a workflow run that gets re-run via the UI
+# keeps its original created_at — measuring against that wraps in the
+# (sometimes very long) idle interval between attempts. run_started_at
+# moves to the latest attempt's start, so updated_at - run_started_at
+# is the wall-clock duration of the latest attempt regardless of how
+# many days passed since the original PR push. For attempt=1 runs the
+# two timestamps are identical, so the change is a no-op there.
 #
 # Output: one JSON object per workflow on stdout, e.g.
 #   {"platform":"kotlin","label":"kotlin","p95_seconds":1320,"p95_minutes":22,"count":18}
@@ -28,7 +34,8 @@ while IFS= read -r entry; do
   # is what updated_at captures.
   durations=$(fetch_runs "$repo" "$workflow_path" "event=pull_request&created=>=$SINCE" \
     | jq -r 'select(.status == "completed" and (.conclusion == "success" or .conclusion == "failure")) |
-             ((.updated_at | fromdateiso8601) - (.created_at | fromdateiso8601))')
+             select(.run_started_at != null) |
+             ((.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601))')
 
   if [[ -z "$durations" ]]; then
     jq -nc --arg p "$platform" --arg l "$label" \

--- a/metrics/scripts/kpi_p95_feedback.sh
+++ b/metrics/scripts/kpi_p95_feedback.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 # Compute 7-day P95 PR feedback time per workflow.
 #
-# Definition: P95 of (run.updated_at - run.run_started_at) over PR-time
-# runs (event = pull_request) in the last 7 days. We use run_started_at,
-# NOT created_at, because a workflow run that gets re-run via the UI
-# keeps its original created_at — measuring against that wraps in the
-# (sometimes very long) idle interval between attempts. run_started_at
-# moves to the latest attempt's start, so updated_at - run_started_at
-# is the wall-clock duration of the latest attempt regardless of how
-# many days passed since the original PR push. For attempt=1 runs the
-# two timestamps are identical, so the change is a no-op there.
+# Definition: P95 over PR-time runs (event = pull_request) of
+#   max(job.completed_at) - min(job.started_at)
+# across the run's non-skipped jobs. We measure from when the first
+# job actually starts to when the last job completes, deliberately
+# excluding the runner-allocation queue wait that sits between the
+# run's `run_started_at` and the first job's `started_at`. Using the
+# run-level `updated_at - run_started_at` would include that queue
+# wait, which inflated rn's P95 to 1055m on 2026-06-17 when GH's
+# macOS pool kept runs queued for 20+ minutes before any job ran.
+#
+# Trade-off: this is "CI compute wall-clock" rather than "developer
+# feedback wall-clock". Queue-wait pain is a separate problem and
+# deserves its own metric — measuring it here would conflate two
+# different problems under one P95.
+#
+# Per-run cost: 1 extra API call to /actions/runs/{id}/jobs. With
+# ~14 completed runs/platform/week × 5 platforms, that's ~70 extra
+# calls per digest, well within the 5000/hour primary rate limit.
 #
 # Output: one JSON object per workflow on stdout, e.g.
 #   {"platform":"kotlin","label":"kotlin","p95_seconds":1320,"p95_minutes":22,"count":18}
@@ -28,14 +37,41 @@ while IFS= read -r entry; do
   label=$(jq -r '.label' <<<"$entry")
   platform=$(jq -r '.platform' <<<"$entry")
 
-  # Filter to runs that actually completed with a real outcome — `cancelled`
-  # / `skipped` / `startup_failure` etc. inflate P95 because the run sits
-  # queued (or limps along) for hours before the final state change, which
-  # is what updated_at captures.
-  durations=$(fetch_runs "$repo" "$workflow_path" "event=pull_request&created=>=$SINCE" \
-    | jq -r 'select(.status == "completed" and (.conclusion == "success" or .conclusion == "failure")) |
-             select(.run_started_at != null) |
-             ((.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601))')
+  # Restrict to runs that actually completed with a real outcome. `cancelled`
+  # / `skipped` / `startup_failure` etc. don't represent a feedback event.
+  # Emit `id<TAB>run_started_at` per line so the inner loop can filter jobs
+  # to only those that ran in the latest attempt.
+  run_meta=$(fetch_runs "$repo" "$workflow_path" "event=pull_request&created=>=$SINCE" \
+    | jq -r 'select(.status == "completed" and (.conclusion == "success" or .conclusion == "failure"))
+             | select(.run_started_at != null)
+             | "\(.id)\t\(.run_started_at)"')
+
+  # For each qualifying run, fetch its jobs and compute
+  #   max(job.completed_at) - min(job.started_at)
+  # over non-skipped jobs that started at-or-after run_started_at. The
+  # last filter is critical for re-runs: GH's "Re-run failed jobs" only
+  # re-executes the failed jobs, but the unchanged jobs still come back
+  # tagged with the new run_attempt and their original (old-day)
+  # started_at. Without the time filter, max(completed) - min(started)
+  # spans the gap between attempts (17h+ in the 2026-06-17 outlier).
+  #
+  # `gh api --paginate` concatenates multiple `{total_count, jobs:[...]}`
+  # objects (one per page); jq -s flattens across pages before reducing.
+  durations=""
+  while IFS=$'\t' read -r run_id run_started_at; do
+    [[ -z "$run_id" ]] && continue
+    d=$(gh api "repos/$repo/actions/runs/$run_id/jobs?per_page=100" --paginate 2>/dev/null \
+      | jq -s --arg t "$run_started_at" '
+          [.[].jobs[]]
+          | map(select(.status == "completed" and (.conclusion // "") != "skipped"
+                       and .started_at != null and .completed_at != null
+                       and .started_at >= $t))
+          | if length > 0 then
+              (map(.completed_at | fromdateiso8601) | max) - (map(.started_at | fromdateiso8601) | min)
+            else empty end' 2>/dev/null) || continue
+    [[ -n "$d" ]] && durations+="${d}"$'\n'
+  done <<< "$run_meta"
+  durations="${durations%$'\n'}"
 
   if [[ -z "$durations" ]]; then
     jq -nc --arg p "$platform" --arg l "$label" \


### PR DESCRIPTION
## Bug

KPI digest reports **rn P95 = 1055m** (17.5h), but the underlying workflow runs visibly finish in ~30–60m. After a colleague flagged that even ~30m doesn't match the **iOS-job** wall-clock of 36m, two cascading issues turned out to be at play.

## What this PR's final formula is

```
duration_per_run = max(job.completed_at) - min(job.started_at)
                   over jobs that completed (success/failure) and started_at >= run_started_at
P95 = 95th percentile of duration_per_run over the 7d PR-run window
```

i.e. **CI compute wall-clock from first job start to last job complete**, excluding runner queue wait, excluding inter-attempt gaps for re-runs.

## Three iterations to land here

| iteration | formula | rn P95 | issue |
|---|---|---|---|
| original | `updated_at - created_at` | **1055m** | reruns reset run_started_at but keep created_at — wraps in 17h between-attempt idle |
| v1 (first commit on this PR) | `updated_at - run_started_at` | **64m** | accurate for reruns, but includes runner-allocation queue (~24m on macOS-XL in rn's case) |
| v2 — without latest-attempt filter | `max(job.completed_at) - min(job.started_at)` | **1055m** | jobs endpoint returns a mix of attempt-1 and attempt-2 jobs for re-runs (only failed jobs re-execute; unchanged jobs keep old `started_at` but get new `run_attempt`) |
| **v3 — final commit** | as v2, plus `job.started_at >= run_started_at` | **38m** | ✓ |

## Why both filters matter

**Re-runs**: GH's "Re-run failed jobs" only re-executes the failed subset. The unchanged jobs come back tagged with the new `run_attempt` but their `started_at` is from the original attempt — sometimes a day earlier. Filtering jobs to `started_at >= run_started_at` keeps only the jobs that actually ran in the latest attempt.

Confirmed against run 27374844404 (rn-examples, attempt=2):
- Latest attempt's `run_started_at`: `2026-06-12T13:20:43Z`
- iOS job (rerun): `started_at` = `13:20:49Z` → included ✓
- Android job (NOT rerun, kept old timestamps): `started_at` = `2026-06-11T20:19:12Z` → excluded ✓

After filter: duration = 13:54:00 − 13:20:49 = **33m 11s** (only the iOS rerun's wall-clock). Was: 17h.

**Why exclude queue wait**: it's real developer friction, but it's a different problem with different fixes (runner pool selection, GH plan, infra). Conflating it into "P95 PR feedback" hides the actual job-duration trend behind queueing noise. If we want a queue-wait metric, it's a separate cell.

## Dry-run on today's rn 7d window

```
 1.0 min   25.2   25.9   26.1   26.4   26.6   26.6   27.5   31.3   31.5   33.2   33.4   37.1   38.4
                                                                                       ^ rerun (was 1055m)  ^ P95 = 38m
```

## Performance

Per-run cost: 1 extra paginated API call to `/actions/runs/{id}/jobs`. For ~14 completed runs/platform × 5 platforms = ~70 extra calls per daily digest, well below GitHub's 5000/hour primary rate limit.

## Test plan

- [ ] Manual trigger via `gh workflow run maestro-kpi-aggregate.yml --repo WalletConnect/actions`
- [ ] Tomorrow's 09:00 UTC digest shows rn at ~38m (not 1055m, not 64m). Other platforms should move down by their typical queue wait (a few minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)