### PR TITLE
fix(permit2-reset): add opt-in fail-on-error for best-effort callers

### DIFF
--- a/maestro/permit2-reset/action.yml
+++ b/maestro/permit2-reset/action.yml
@@ -30,6 +30,15 @@ inputs:
     description: 'Override the min priority fee (gwei). Optional.'
     required: false
     default: ''
+  fail-on-error:
+    description: |
+      When 'false', a revoke failure (RPC error, insufficient gas, etc.) logs a
+      warning and exits 0 instead of failing the job. Best-effort cleanup callers
+      (post-test allowance reset) should set this to 'false'. Default 'true' keeps
+      strict behavior. Needed because `continue-on-error` on a step that `uses:`
+      this composite action is ignored by the runner (actions/runner#1457).
+    required: false
+    default: 'true'
   node-version:
     description: 'Node.js version used to run the helper.'
     required: false
@@ -57,9 +66,19 @@ runs:
         RPC_URL: ${{ inputs.rpc-url }}
         TOKEN_ADDRESS: ${{ inputs.token-address }}
         MIN_PRIORITY_FEE_GWEI: ${{ inputs.min-priority-fee-gwei }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+      # set +e: GitHub's default `bash -e` would abort on a node failure before
+      # we can inspect $? and honor fail-on-error.
       run: |
+        set +e
         node revoke-permit2-approval.js \
           --chainId "$CHAIN_ID" \
           --rpcUrl "$RPC_URL" \
           ${TOKEN_ADDRESS:+--tokenAddress "$TOKEN_ADDRESS"} \
           ${MIN_PRIORITY_FEE_GWEI:+--minPriorityFeeGwei "$MIN_PRIORITY_FEE_GWEI"}
+        status=$?
+        if [ "$status" -ne 0 ] && [ "$FAIL_ON_ERROR" = "false" ]; then
+          echo "::warning::Permit2 allowance reset failed (exit $status); continuing (fail-on-error=false)."
+          exit 0
+        fi
+        exit "$status"


### PR DESCRIPTION
## Problem

The post-test Permit2 allowance reset is best-effort cleanup, but a revoke failure (RPC error, insufficient gas, etc.) currently fails the whole job.

In `walletkit-build-and-maestro` the reset step sets `continue-on-error: true`, but the runner **ignores `continue-on-error` on steps inside composite actions** ([actions/runner#1457](https://github.com/actions/runner/issues/1457), [#3510](https://github.com/actions/runner/issues/3510)). So the failure propagates and reddens the job.

This surfaced in pay-core CD: the reset wallet ran out of POL on Polygon and the `WX Pay E2E Maestro - android - staging` job went red on the revoke step (on top of an NDK build failure, fixed separately).

## Change

Add a `fail-on-error` input (default `'true'`, preserving current strict behavior). When `'false'`, a revoke failure logs a `::warning::` and exits 0.

`set +e` is required because GitHub's default `bash -e` would abort on the node failure before we can inspect `$?`.

Best-effort callers (post-test allowance reset) pass `fail-on-error: 'false'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)