### PR TITLE
fix(pay-tests): retry create-payment.js on transient Pay API failures

### DIFF
--- a/maestro/pay-tests/.maestro/scripts/create-payment.js
+++ b/maestro/pay-tests/.maestro/scripts/create-payment.js
@@ -10,20 +10,47 @@ var baseUrl = (typeof WPAY_PAY_API_URL !== 'undefined' && WPAY_PAY_API_URL)
   ? WPAY_PAY_API_URL
   : 'https://api.pay.walletconnect.com';
 
-var response = http.post(baseUrl + '/v1/payments', {
-  headers: {
-    'Content-Type': 'application/json',
-    'Api-Key': WPAY_CUSTOMER_KEY,
-    'Merchant-Id': WPAY_MERCHANT_ID,
-  },
-  body: JSON.stringify({
-    referenceId: '' + Date.now() + Math.random().toString(36).substring(2, 10),
-    amount: { value: typeof WPAY_AMOUNT !== 'undefined' ? WPAY_AMOUNT : '1', unit: 'iso4217/USD' },
-  }),
-});
+// Retry the create call. This is a single host-side network hop and, unlike the
+// in-app steps (which run under a Maestro `retry {}`), nothing wraps it — so a
+// single transient 5xx/timeout from the Pay API otherwise fails the whole flow
+// in ~1s, before the app is even launched. Linear backoff; Maestro's JS runtime
+// has no setTimeout, so we busy-wait between attempts.
+var MAX_ATTEMPTS = 4;
+var response = null;
+var lastError = '';
 
-if (response.status < 200 || response.status >= 300) {
-  throw new Error('API returned HTTP ' + response.status + ': ' + response.body);
+for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  try {
+    var r = http.post(baseUrl + '/v1/payments', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': WPAY_CUSTOMER_KEY,
+        'Merchant-Id': WPAY_MERCHANT_ID,
+      },
+      body: JSON.stringify({
+        referenceId: '' + Date.now() + Math.random().toString(36).substring(2, 10),
+        amount: { value: typeof WPAY_AMOUNT !== 'undefined' ? WPAY_AMOUNT : '1', unit: 'iso4217/USD' },
+      }),
+    });
+    if (r.status >= 200 && r.status < 300) {
+      response = r;
+      break;
+    }
+    lastError = 'HTTP ' + r.status + ': ' + r.body;
+  } catch (e) {
+    lastError = '' + e;
+  }
+
+  console.log('create-payment attempt ' + attempt + '/' + MAX_ATTEMPTS + ' failed: ' + lastError);
+
+  if (attempt < MAX_ATTEMPTS) {
+    var until = Date.now() + attempt * 1500; // 1.5s, 3s, 4.5s
+    while (Date.now() < until) { /* busy-wait: no setTimeout in Maestro JS */ }
+  }
+}
+
+if (!response) {
+  throw new Error('create-payment failed after ' + MAX_ATTEMPTS + ' attempts. Last error: ' + lastError);
 }
 
 var data = json(response.body);


### PR DESCRIPTION
## Problem

`maestro/pay-tests/.maestro/scripts/create-payment.js` is the first step of every `pay_*` flow and the **only network hop not wrapped in a Maestro `retry {}`** (the in-app steps retry the app launch). It did a single `http.post` and `throw`s on any non-2xx or missing `gatewayUrl`, so a transient 5xx/timeout from `api.pay.walletconnect.com` fails the **whole flow in ~1s**, before the app is even launched.

### Observed

In the reown-kotlin **E2E Pay Tests with Maestro** CI, the `Insufficient Funds` flow failed at **1s** across consecutive runs with:
- no app-side activity in logcat (a cold app launch alone takes 30–40s),
- only the residual scanner screenshot,

while passing in other runs with the same `$9.99` amount — classic unretried-network-call flakiness, not an app or balance issue.

- Failing run: https://github.com/reown-com/reown-kotlin/actions/runs/27958574596/job/82741264429

## Fix

Wrap the create POST in a bounded retry: 4 attempts with linear backoff (1.5s / 3s / 4.5s; Maestro's JS runtime has no `setTimeout`, so we busy-wait). Retries on both non-2xx responses and thrown network errors. On success, behavior is unchanged — same `gatewayUrl`/`paymentId` outputs, same hard failure (with attempt history) only after all attempts are exhausted.

This is the only unretried step in the suite, so it's the right place to harden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)