### PR TITLE
fix(pay-tests): fail fast on non-retryable create-payment errors

### DIFF
--- a/maestro/pay-tests/.maestro/scripts/create-payment.js
+++ b/maestro/pay-tests/.maestro/scripts/create-payment.js
@@ -10,16 +10,31 @@ var baseUrl = (typeof WPAY_PAY_API_URL !== 'undefined' && WPAY_PAY_API_URL)
   ? WPAY_PAY_API_URL
   : 'https://api.pay.walletconnect.com';
 
-// Retry the create call. This is a single host-side network hop and, unlike the
-// in-app steps (which run under a Maestro `retry {}`), nothing wraps it — so a
-// single transient 5xx/timeout from the Pay API otherwise fails the whole flow
-// in ~1s, before the app is even launched. Linear backoff; Maestro's JS runtime
-// has no setTimeout, so we busy-wait between attempts.
+// This is a single host-side network hop and, unlike the in-app steps (which run
+// under a Maestro `retry {}`), nothing wraps it. We retry it, but only for
+// TRANSIENT failures (5xx, 429, network error) — a transient blot otherwise fails
+// the whole flow before the app even launches.
+//
+// A deterministic 4xx (e.g. 400 params_validation when the requested amount
+// exceeds the merchant's per-payment cap) will NEVER succeed on retry, so we fail
+// fast on it instead of burning ~10s of backoff on a guaranteed-lost cause. The
+// thrown error carries the HTTP status + body so the real reason is visible rather
+// than a silent "flow failed in 1s".
+//
+// Linear backoff; Maestro's JS runtime has no setTimeout, so we busy-wait.
 var MAX_ATTEMPTS = 4;
 var response = null;
 var lastError = '';
 
+function isRetryable(status) {
+  // No HTTP status -> a thrown network/timeout error -> retry.
+  // 429 (rate limited) and 5xx (server) are transient -> retry.
+  // Everything else (incl. 4xx validation/auth) is deterministic -> don't retry.
+  return status === 0 || status === 429 || status >= 500;
+}
+
 for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  var status = 0;
   try {
     var r = http.post(baseUrl + '/v1/payments', {
       headers: {
@@ -36,12 +51,19 @@ for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       response = r;
       break;
     }
+    status = r.status;
     lastError = 'HTTP ' + r.status + ': ' + r.body;
   } catch (e) {
+    status = 0;
     lastError = '' + e;
   }
 
-  console.log('create-payment attempt ' + attempt + '/' + MAX_ATTEMPTS + ' failed: ' + lastError);
+  // Deterministic error (e.g. 4xx) -> stop now and surface the real reason.
+  if (!isRetryable(status)) {
+    throw new Error('create-payment rejected (not retryable): ' + lastError);
+  }
+
+  console.log('create-payment attempt ' + attempt + '/' + MAX_ATTEMPTS + ' failed (transient): ' + lastError);
 
   if (attempt < MAX_ATTEMPTS) {
     var until = Date.now() + attempt * 1500; // 1.5s, 3s, 4.5s
@@ -50,7 +72,7 @@ for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 }
 
 if (!response) {
-  throw new Error('create-payment failed after ' + MAX_ATTEMPTS + ' attempts. Last error: ' + lastError);
+  throw new Error('create-payment failed after ' + MAX_ATTEMPTS + ' transient attempts. Last error: ' + lastError);
 }
 
 var data = json(response.body);


### PR DESCRIPTION
## Problem

The retry added in #102 retries **all** non-2xx responses. But a deterministic 4xx — e.g. `400 params_validation` when the requested amount exceeds the merchant's per-payment cap — can never succeed on retry. So the flow burns ~10s of backoff (1.5s + 3s + 4.5s) before throwing a generic "failed after 4 attempts" message, and the **real cause is invisible in CI** because Maestro's compact reporter swallows `runScript` stdout.

Observed in reown-kotlin E2E Pay: the `Insufficient Funds` flow (which posts a `$9.99` charge to exceed the wallet balance) hit `payment amount exceeds the per-payment cap of $0.05` — a hard 400 — and surfaced only as a silent `[Failed] ... (10s)`.

## Fix

Classify the failure:
- **Transient** (thrown network/timeout, `429`, `5xx`) → retry with backoff, as before.
- **Anything else** (incl. `4xx` validation/auth) → throw **immediately** with the HTTP status + body, so the actual reason is visible instead of a slow silent failure.

This doesn't mask a genuinely-failing precondition (a rejected create still fails the flow, correctly), it just makes that failure fast and self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)