### PR TITLE
fix(metrics): match the moved pay-core CD Maestro job (Advisory)

### DIFF
--- a/metrics/config/workflows.json
+++ b/metrics/config/workflows.json
@@ -42,7 +42,7 @@
       "repo": "WalletConnect/pay-core",
       "workflow_path": ".github/workflows/event_release.yml",
       "branch": "main",
-      "job_pattern": "^CD / Validate Staging / WX Pay E2E Maestro - android - staging$"
+      "job_pattern": "^CD / Validate Staging \\(Advisory\\) / WX Pay E2E Maestro - android - staging$"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The Maestro KPI dashboard shows **`core (CD): no runs`** even though pay-core's CD Maestro job runs on every release and is now passing (latest event_release run: `CD / Validate Staging (Advisory) / WX Pay E2E Maestro - android - staging` → **success**, 11/11 flows).

The `core (CD)` entry's `job_pattern` is:
```
^CD / Validate Staging / WX Pay E2E Maestro - android - staging$
```
But the job was **moved** out of the blocking `validate-staging` job into the advisory soak workflow and is now named:
```
CD / Validate Staging (Advisory) / WX Pay E2E Maestro - android - staging
```
(note the `(Advisory)`). `resolve_conclusions` runs this pattern through jq `test()`; with no match it returns no conclusion, so **every CD run is dropped** → "no runs", independent of pass/fail.

## Fix

Update the pattern to the current job name, escaping the parens for the jq regex:
```
^CD / Validate Staging \(Advisory\) / WX Pay E2E Maestro - android - staging$
```

Verified with `jq test`:
- ✅ matches `CD / Validate Staging (Advisory) / WX Pay E2E Maestro - android - staging`
- ❌ old name (gone) — no match
- ❌ `CD / Validate Prod (Advisory) / … - prod` — no match (core (CD) tracks staging only)

JSON validates. No script changes — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)