### PR TITLE
feat(maestro/pay-tests): add web-only pay flows (in-app IC form)

### DIFF
--- a/maestro/pay-tests/.maestro/flows/pay_submit_collect_data_web.yaml
+++ b/maestro/pay-tests/.maestro/flows/pay_submit_collect_data_web.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+---
+# Shared (web-only) flow: submit the in-app identity-collection form.
+#
+# On web the IC/KYC form is rendered in-app from collectData.fields
+# (CollectDataWebView.web.tsx) instead of the hosted webview. Fields are
+# prefilled & valid, so we just tap Continue; the collected values are sent
+# via confirmPayment's collectedData. Reused by the pay-web KYC flows.
+- extendedWaitUntil:
+    visible:
+      id: "pay-collect-submit"
+    timeout: 15000
+- tapOn:
+    id: "pay-collect-submit"

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
@@ -26,6 +26,9 @@ tags:
     timeout: 30000
 - assertVisible:
     id: "pay-option-0"
+# Verify at least a second option exists (genuinely multi-option payload)
+- assertVisible:
+    id: "pay-option-1"
 
 # Select the first option — opens the in-app identity form
 - tapOn:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
@@ -5,7 +5,6 @@ name: WalletConnect Pay - Cancel from KYC (web in-app form)
 # form is showing, submit it, then pay — confirmPayment returns `cancelled`.
 tags:
   - pay-web
-  - pay-needs-kyc-backend
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc_web.yaml
@@ -1,0 +1,68 @@
+appId: ${APP_ID}
+name: WalletConnect Pay - Cancel from KYC (web in-app form)
+# Web equivalent of pay_cancel_from_kyc (which drives the hosted KYC webview).
+# On web the IC form is in-app, so we cancel the payment server-side while the
+# form is showing, submit it, then pay — confirmPayment returns `cancelled`.
+tags:
+  - pay-web
+  - pay-needs-kyc-backend
+---
+# Create payment via API (multi-option, KYC merchant)
+- runScript:
+    file: scripts/create-payment.js
+    env:
+      WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
+      WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
+
+- clearState
+
+# Open wallet, paste payment URL
+- runFlow:
+    file: flows/pay_open_and_paste_url.yaml
+
+# Multi-option KYC merchant — wait for the select screen
+- extendedWaitUntil:
+    visible:
+      id: "pay-select-option-header"
+    timeout: 30000
+- assertVisible:
+    id: "pay-option-0"
+
+# Select the first option — opens the in-app identity form
+- tapOn:
+    id: "pay-option-0"
+- extendedWaitUntil:
+    visible:
+      id: "pay-collect-submit"
+    timeout: 15000
+
+# Cancel the payment server-side while the form is showing
+- runScript:
+    file: scripts/cancel-payment.js
+    env:
+      WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
+      WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
+      PAYMENT_ID: ${output.payment_id}
+
+# Submit the form and attempt to pay — the cancelled payment yields a
+# cancelled result from confirmPayment.
+- runFlow:
+    file: flows/pay_submit_collect_data_web.yaml
+- extendedWaitUntil:
+    visible:
+      id: "pay-button-pay"
+    timeout: 15000
+- tapOn:
+    id: "pay-button-pay"
+
+# Cancelled result screen
+- extendedWaitUntil:
+    visible:
+      id: "pay-result-container"
+    timeout: 30000
+- assertVisible:
+    id: "pay-result-cancelled-icon"
+- assertVisible:
+    id: "pay-button-result-action-cancelled"
+- tapOn:
+    id: "pay-button-result-action-cancelled"

--- a/maestro/pay-tests/.maestro/pay_double_scan.yaml
+++ b/maestro/pay-tests/.maestro/pay_double_scan.yaml
@@ -2,9 +2,10 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Double Scan Same Payment
 tags:
   - pay
-  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
-  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  # On-chain: broadcasts a payment tx on Base. The web CI leg buckets on-chain
+  # flows by chain (same chain = serial nonce; different chains run concurrently).
   - pay-onchain
+  - pay-chain-base
 ---
 # Create payment via API (single-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_double_scan.yaml
+++ b/maestro/pay-tests/.maestro/pay_double_scan.yaml
@@ -2,6 +2,9 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Double Scan Same Payment
 tags:
   - pay
+  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
+  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  - pay-onchain
 ---
 # Create payment via API (single-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_web.yaml
@@ -7,7 +7,6 @@ name: WalletConnect Pay - Multiple Options KYC (web in-app form)
 # Web equivalent of pay_multiple_options_kyc (which is hosted-webview-only).
 tags:
   - pay-web
-  - pay-needs-kyc-backend
   # On-chain: broadcasts a payment tx on Base (first option). The web CI leg
   # buckets on-chain flows by chain (same chain = serial nonce; different
   # chains run concurrently).

--- a/maestro/pay-tests/.maestro/pay_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_web.yaml
@@ -1,0 +1,43 @@
+appId: ${APP_ID}
+name: WalletConnect Pay - Multiple Options KYC (web in-app form)
+# Web-only: the `pay-web` tag keeps this out of native runs (which use
+# `--include-tags pay`). On web the identity-collection form is rendered in-app
+# from collectData.fields (CollectDataWebView.web.tsx) instead of the hosted
+# webview, so the values are submitted via confirmPayment's collectedData.
+# Web equivalent of pay_multiple_options_kyc (which is hosted-webview-only).
+tags:
+  - pay-web
+  - pay-needs-kyc-backend
+---
+# Create payment via API (multi-option, KYC merchant)
+- runScript:
+    file: scripts/create-payment.js
+    env:
+      WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_KYC}
+      WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
+
+- clearState
+
+# Open wallet, paste payment URL
+- runFlow:
+    file: flows/pay_open_and_paste_url.yaml
+
+# Multi-option KYC merchant — wait for the select screen
+- extendedWaitUntil:
+    visible:
+      id: "pay-select-option-header"
+    timeout: 30000
+
+# KYC options surface the "info required" marker
+- assertVisible:
+    id: "pay-option-info-required"
+
+# Select the first option (requires identity collection)
+- tapOn:
+    id: "pay-option-0"
+
+# Submit the in-app identity form, then pay and verify success
+- runFlow:
+    file: flows/pay_submit_collect_data_web.yaml
+- runFlow:
+    file: flows/pay_confirm_and_verify.yaml

--- a/maestro/pay-tests/.maestro/pay_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_web.yaml
@@ -8,9 +8,11 @@ name: WalletConnect Pay - Multiple Options KYC (web in-app form)
 tags:
   - pay-web
   - pay-needs-kyc-backend
-  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
-  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  # On-chain: broadcasts a payment tx on Base (first option). The web CI leg
+  # buckets on-chain flows by chain (same chain = serial nonce; different
+  # chains run concurrently).
   - pay-onchain
+  - pay-chain-base
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_web.yaml
@@ -8,6 +8,9 @@ name: WalletConnect Pay - Multiple Options KYC (web in-app form)
 tags:
   - pay-web
   - pay-needs-kyc-backend
+  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
+  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  - pay-onchain
 ---
 # Create payment via API (multi-option, KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_kyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_kyc_web.yaml
@@ -36,6 +36,13 @@ tags:
 - assertVisible:
     id: "pay-option-info-required"
 
+# Verify this is genuinely a multi-option payload (guards against a backend
+# regression silently dropping to a single option)
+- assertVisible:
+    id: "pay-option-0"
+- assertVisible:
+    id: "pay-option-1"
+
 # Select the first option (requires identity collection)
 - tapOn:
     id: "pay-option-0"

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
@@ -1,0 +1,39 @@
+appId: ${APP_ID}
+name: WalletConnect Pay - Multiple Payment Options without KYC (web)
+# Web equivalent of pay_multiple_options_nokyc. The native flow correlates the
+# selected option to the review screen via copyTextFrom(pay-option) -> network
+# name, which comes from the option's accessibilityLabel. Maestro web can't read
+# aria-label (and the network name isn't visible text), so this web variant
+# drops that one correlation assertion and keeps the rest: multiple options
+# present -> select one -> review -> pay -> success.
+tags:
+  - pay-web
+---
+# Create payment via API (multi-option, no-KYC merchant)
+- runScript:
+    file: scripts/create-payment.js
+    env:
+      WPAY_CUSTOMER_KEY: ${WPAY_CUSTOMER_KEY_MULTI_NOKYC}
+      WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_NOKYC}
+
+- clearState
+
+# Open wallet, paste payment URL
+- runFlow:
+    file: flows/pay_open_and_paste_url.yaml
+
+# Wait for the select screen and verify multiple options are present
+- extendedWaitUntil:
+    visible:
+      id: "pay-select-option-header"
+    timeout: 30000
+- assertVisible:
+    id: "pay-option-0"
+- assertVisible:
+    id: "pay-option-1"
+
+# Select the second option, then pay and verify success
+- tapOn:
+    id: "pay-option-1"
+- runFlow:
+    file: flows/pay_confirm_and_verify.yaml

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
@@ -8,9 +8,11 @@ name: WalletConnect Pay - Multiple Payment Options without KYC (web)
 # present -> select one -> review -> pay -> success.
 tags:
   - pay-web
-  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
-  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  # On-chain: broadcasts a payment tx on Polygon (second option). The web CI leg
+  # buckets on-chain flows by chain (same chain = serial nonce; different
+  # chains run concurrently).
   - pay-onchain
+  - pay-chain-polygon
 ---
 # Create payment via API (multi-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_nokyc_web.yaml
@@ -8,6 +8,9 @@ name: WalletConnect Pay - Multiple Payment Options without KYC (web)
 # present -> select one -> review -> pay -> success.
 tags:
   - pay-web
+  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
+  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  - pay-onchain
 ---
 # Create payment via API (multi-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -2,9 +2,10 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Single Payment Option without KYC
 tags:
   - pay
-  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
-  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  # On-chain: broadcasts a payment tx on Base. The web CI leg buckets on-chain
+  # flows by chain (same chain = serial nonce; different chains run concurrently).
   - pay-onchain
+  - pay-chain-base
 ---
 # Create payment via API (single-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_single_option_nokyc.yaml
@@ -2,6 +2,9 @@ appId: ${APP_ID}
 name: WalletConnect Pay - Single Payment Option without KYC
 tags:
   - pay
+  # Broadcasts an on-chain payment tx -> shares the test wallet's nonce, so the
+  # web CI leg keeps pay-onchain flows serial (read-only flows run concurrently).
+  - pay-onchain
 ---
 # Create payment via API (single-option, no-KYC merchant)
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
+++ b/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
@@ -3,6 +3,9 @@ name: WalletConnect Pay - USDT on Polygon (Permit2 approve + pay)
 tags:
   - pay
   - pay-usdt-polygon
+  # Broadcasts on-chain txs (Permit2 approve + payment) -> shares the test
+  # wallet's nonce, so the web CI leg keeps pay-onchain flows serial.
+  - pay-onchain
 ---
 # Create payment via API (merchant that offers USDT on Polygon).
 - runScript:

--- a/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
+++ b/maestro/pay-tests/.maestro/pay_usdt_polygon.yaml
@@ -3,9 +3,11 @@ name: WalletConnect Pay - USDT on Polygon (Permit2 approve + pay)
 tags:
   - pay
   - pay-usdt-polygon
-  # Broadcasts on-chain txs (Permit2 approve + payment) -> shares the test
-  # wallet's nonce, so the web CI leg keeps pay-onchain flows serial.
+  # On-chain: broadcasts txs on Polygon (Permit2 approve + payment). The web CI
+  # leg buckets on-chain flows by chain (same chain = serial nonce; different
+  # chains run concurrently).
   - pay-onchain
+  - pay-chain-polygon
 ---
 # Create payment via API (merchant that offers USDT on Polygon).
 - runScript:

--- a/maestro/permit2-reset/revoke-permit2-approval.js
+++ b/maestro/permit2-reset/revoke-permit2-approval.js
@@ -322,15 +322,20 @@ async function main() {
 
   // tx.wait() has no built-in timeout; a dropped/underpriced tx would hang the
   // CI job until its wall-clock limit. Race it against a deadline instead.
+  // clearTimeout in finally: when tx.wait() wins the race, the timeout's timer
+  // is still pending and (being a normal ref'd timer) keeps Node's event loop
+  // alive for the full timeout (~2 min) after a successful revoke before the
+  // process can exit. Clearing it lets the process exit promptly.
+  let waitTimer;
   const receipt = await Promise.race([
     tx.wait(),
-    new Promise((_, reject) =>
-      setTimeout(
+    new Promise((_, reject) => {
+      waitTimer = setTimeout(
         () => reject(new Error(`tx.wait() timed out after ${TX_WAIT_TIMEOUT_MS / 1000}s`)),
         TX_WAIT_TIMEOUT_MS,
-      ),
-    ),
-  ]);
+      );
+    }),
+  ]).finally(() => clearTimeout(waitTimer));
   if (receipt.status !== 1) {
     throw new Error('Transaction reverted.');
   }


### PR DESCRIPTION
## Summary
The RN reference wallet (`reown-com/react-native-examples`) now runs on **web** (react-native-web) for Maestro E2E. On web the identity-collection (KYC) form is rendered **in-app** from `collectData.fields` instead of the hosted webview, and the values are submitted via `confirmPayment`'s `collectedData`.

This adds `pay-web`-tagged flows so web runs can cover the KYC + multi-option paths that the native flows express against the hosted webview / native accessibility. They are tagged `pay-web` (not `pay`), so native runs (`--include-tags pay`) never pick them up.

## New flows (`maestro/pay-tests/.maestro/`)
- **`pay_kyc_web.yaml`** — multi-option KYC merchant → in-app form (`pay-collect-submit`) → pay → success. Web equivalent of `pay_multiple_options_kyc` (hosted-webview-only).
- **`pay_cancel_from_kyc_web.yaml`** — cancel the payment server-side while the in-app form is showing → pay → `cancelled` result. Web equivalent of `pay_cancel_from_kyc`.
- **`pay_multiple_options_nokyc_web.yaml`** — multi-option select → pay → success. Web equivalent of `pay_multiple_options_nokyc`; drops the option→review network-name correlation (it reads the option's `accessibilityLabel`, which Maestro web can't access).
- **`flows/pay_submit_collect_data_web.yaml`** — shared subflow that submits the in-app IC form (reused by the KYC web flows).

## How web runs consume these
The wallet's CI composite (`walletkit-build-and-maestro`) will run the web leg with `--include-tags pay,pay-web` against a `url:` target (expo web), rewriting `appId:`→`url:`, stripping `startRecording` (unsupported on web), and skipping the hosted-webview/deeplink flows. The flows themselves stay platform-agnostic here.

All four validated green locally against the web build (Maestro 2.0.10, managed Chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)