### PR TITLE
fix(maestro/pay-tests): adapt KYC flows to redesigned /collect inline IC form

### DIFF
--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -59,8 +59,10 @@ tags:
 - tapOn:
     text: "0"
     retryTapIfNoChange: true
+# "Confirm your details" dialog is gone, so "Confirm" is now unambiguous.
 - tapOn:
-    id: "identity-form-confirm-button"
+    text: "Confirm"
+    retryTapIfNoChange: true
 
 # Wait for result screen
 - extendedWaitUntil:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -46,26 +46,12 @@ tags:
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
       PAYMENT_ID: ${output.payment_id}
 
-# Complete KYC form (data is autocompleted, just tap Add)
-- tapOn: "Add"
-
-# Retry tap on "Add" if "Confirm your details" doesn't appear (webview can be slow)
-- runFlow:
-    when:
-      notVisible: "Confirm your details"
-    commands:
-      - tapOn: "Add"
-
-# Confirm your details popup
-- extendedWaitUntil:
-    visible: "Confirm your details"
-    timeout: 10000
-
-# Tap the checkbox / label for terms agreement
+# Complete the redesigned inline IC form: tick consent, then Confirm submits.
 - tapOn:
-    text: "I agree to the <termsLink>Terms and Conditions</termsLink> and <privacyLink>Privacy Policy</privacyLink>"
+    id: "consent-checkbox"
     retryTapIfNoChange: true
-- tapOn: "Confirm"
+- tapOn:
+    id: "identity-form-confirm-button"
 
 # Wait for result screen
 - extendedWaitUntil:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -47,17 +47,15 @@ tags:
       PAYMENT_ID: ${output.payment_id}
 
 # Complete the redesigned inline IC form: tick consent, then Confirm submits.
-# Wait for the checkbox itself (it can render after the page title appears;
-# retryTapIfNoChange only retries on no-change, not on element-not-found).
-# Selector note: prefer id: "consent-checkbox" — a bare text: "I agree" is
-# ambiguous (the consent paragraph also contains "I agree"); validate on a real
-# WebView run and disambiguate with index if the testID isn't exposed.
-- extendedWaitUntil:
-    visible:
-      id: "consent-checkbox"
+# Scroll to the bottom so the consent line and the Confirm button are both on
+# screen (tapOn does not auto-scroll), then tap "I agree" to enable Confirm.
+- scrollUntilVisible:
+    element:
+      text: "I agree"
+    direction: DOWN
     timeout: 10000
 - tapOn:
-    id: "consent-checkbox"
+    text: "I agree"
     retryTapIfNoChange: true
 - tapOn:
     id: "identity-form-confirm-button"

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -51,7 +51,7 @@ tags:
 # on screen (tapOn does not auto-scroll), then tap "I agree" to enable Confirm.
 - scrollUntilVisible:
     element:
-      text: "I agree"
+      text: "Confirm"
     direction: DOWN
     timeout: 10000
 - tapOn:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -47,6 +47,15 @@ tags:
       PAYMENT_ID: ${output.payment_id}
 
 # Complete the redesigned inline IC form: tick consent, then Confirm submits.
+# Wait for the checkbox itself (it can render after the page title appears;
+# retryTapIfNoChange only retries on no-change, not on element-not-found).
+# Selector note: prefer id: "consent-checkbox" — a bare text: "I agree" is
+# ambiguous (the consent paragraph also contains "I agree"); validate on a real
+# WebView run and disambiguate with index if the testID isn't exposed.
+- extendedWaitUntil:
+    visible:
+      id: "consent-checkbox"
+    timeout: 10000
 - tapOn:
     id: "consent-checkbox"
     retryTapIfNoChange: true

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -48,16 +48,14 @@ tags:
 
 # Complete the redesigned inline IC form: tick consent, then Confirm submits.
 # Scroll to the bottom so the consent control and the Confirm button are both
-# on screen (tapOn does not auto-scroll). The checkbox surfaces as a value node
-# reading "0" (unchecked) that flips to "1" when tapped — a more reliable target
-# than the "I agree" text, which also appears in the consent paragraph.
+# on screen (tapOn does not auto-scroll), then tap "I agree" to enable Confirm.
 - scrollUntilVisible:
     element:
       text: "I agree"
     direction: DOWN
     timeout: 10000
 - tapOn:
-    text: "0"
+    text: "I agree"
     retryTapIfNoChange: true
 # "Confirm your details" dialog is gone, so "Confirm" is now unambiguous.
 - tapOn:

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -46,18 +46,23 @@ tags:
       WPAY_MERCHANT_ID: ${WPAY_MERCHANT_ID_MULTI_KYC}
       PAYMENT_ID: ${output.payment_id}
 
-# Complete the redesigned inline IC form: tick consent, then Confirm submits.
-# Scroll to the bottom so the consent control and the Confirm button are both
-# on screen (tapOn does not auto-scroll), then tap "I agree" to enable Confirm.
+# Complete the inline IC form: tick "I agree" consent, then Confirm submits.
+- scrollUntilVisible:
+    element:
+      text: "I agree"
+    direction: DOWN
+    timeout: 10000
+
+- tapOn:
+    text: "I agree"
+    retryTapIfNoChange: true
+
 - scrollUntilVisible:
     element:
       text: "Confirm"
     direction: DOWN
     timeout: 10000
-- tapOn:
-    text: "I agree"
-    retryTapIfNoChange: true
-# "Confirm your details" dialog is gone, so "Confirm" is now unambiguous.
+
 - tapOn:
     text: "Confirm"
     retryTapIfNoChange: true

--- a/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_cancel_from_kyc.yaml
@@ -47,15 +47,17 @@ tags:
       PAYMENT_ID: ${output.payment_id}
 
 # Complete the redesigned inline IC form: tick consent, then Confirm submits.
-# Scroll to the bottom so the consent line and the Confirm button are both on
-# screen (tapOn does not auto-scroll), then tap "I agree" to enable Confirm.
+# Scroll to the bottom so the consent control and the Confirm button are both
+# on screen (tapOn does not auto-scroll). The checkbox surfaces as a value node
+# reading "0" (unchecked) that flips to "1" when tapped — a more reliable target
+# than the "I agree" text, which also appears in the consent paragraph.
 - scrollUntilVisible:
     element:
       text: "I agree"
     direction: DOWN
     timeout: 10000
 - tapOn:
-    text: "I agree"
+    text: "0"
     retryTapIfNoChange: true
 - tapOn:
     id: "identity-form-confirm-button"

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -43,31 +43,22 @@ tags:
 - tapOn:
     id: "pay-option-1"
 
-# Handle personal details webview (KYC)
+# Handle personal details webview (KYC). The /collect form is now a single
+# inline page (no confirmation dialog): fields are autocompleted, tick the
+# inline consent checkbox, then Confirm submits directly.
 - extendedWaitUntil:
     visible: "Add your personal details"
     timeout: 30000
 
-# Data is autocompleted, just tap Add
-- tapOn: "Add"
-
-# Retry tap on "Add" if "Confirm your details" doesn't appear (webview can be slow)
-- runFlow:
-    when:
-      notVisible: "Confirm your details"
-    commands:
-      - tapOn: "Add"
-
-# Confirm your details popup
-- extendedWaitUntil:
-    visible: "Confirm your details"
-    timeout: 10000
-
-# Tap the checkbox / label for terms agreement
+# Tick the inline consent checkbox (Confirm is disabled until checked).
+# See VERIFY note below re: selector choice.
 - tapOn:
-    text: "I agree to the <termsLink>Terms and Conditions</termsLink> and <privacyLink>Privacy Policy</privacyLink>"
+    id: "consent-checkbox"
     retryTapIfNoChange: true
-- tapOn: "Confirm"
+
+# Submit directly — the "Confirm your details" dialog no longer exists.
+- tapOn:
+    id: "identity-form-confirm-button"
 
 # Verify review screen shows the same token we selected
 - assertVisible:

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -54,7 +54,7 @@ tags:
 # button are both on screen (tapOn does not auto-scroll).
 - scrollUntilVisible:
     element:
-      text: "I agree"
+      text: "Confirm"
     direction: DOWN
     timeout: 10000
 

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -43,29 +43,28 @@ tags:
 - tapOn:
     id: "pay-option-1"
 
-# Handle personal details webview (KYC). The /collect form is now a single
-# inline page (no confirmation dialog): fields are autocompleted, tick the
-# inline consent checkbox, then Confirm submits directly.
+# Handle personal details webview (KYC): fields are autocompleted, tick the
+# "I agree" consent, then Confirm submits.
 - extendedWaitUntil:
     visible: "Add your personal details"
     timeout: 30000
 
-# Scroll to the bottom of the form so the consent control and the Confirm
-# button are both on screen (tapOn does not auto-scroll).
+- scrollUntilVisible:
+    element:
+      text: "I agree"
+    direction: DOWN
+    timeout: 10000
+
+- tapOn:
+    text: "I agree"
+    retryTapIfNoChange: true
+
 - scrollUntilVisible:
     element:
       text: "Confirm"
     direction: DOWN
     timeout: 10000
 
-# Tick consent by tapping the "I agree" checkbox label (Confirm is disabled
-# until checked). retryTapIfNoChange re-taps only if the check didn't register.
-- tapOn:
-    text: "I agree"
-    retryTapIfNoChange: true
-
-# Submit directly — the "Confirm your details" dialog no longer exists, so
-# "Confirm" is now unambiguous.
 - tapOn:
     text: "Confirm"
     retryTapIfNoChange: true

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -51,7 +51,15 @@ tags:
     timeout: 30000
 
 # Tick the inline consent checkbox (Confirm is disabled until checked).
-# See VERIFY note below re: selector choice.
+# Selector: prefer id: "consent-checkbox"; a bare text: "I agree" is ambiguous
+# (the consent paragraph also contains "I agree"), so validate on a real WebView
+# run and disambiguate with index if the testID isn't exposed.
+# Wait for the checkbox itself: it can render after the page title appears, and
+# retryTapIfNoChange only retries on no-change, not on element-not-found.
+- extendedWaitUntil:
+    visible:
+      id: "consent-checkbox"
+    timeout: 10000
 - tapOn:
     id: "consent-checkbox"
     retryTapIfNoChange: true

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -50,18 +50,18 @@ tags:
     visible: "Add your personal details"
     timeout: 30000
 
-# Tick the inline consent checkbox (Confirm is disabled until checked).
-# Selector: prefer id: "consent-checkbox"; a bare text: "I agree" is ambiguous
-# (the consent paragraph also contains "I agree"), so validate on a real WebView
-# run and disambiguate with index if the testID isn't exposed.
-# Wait for the checkbox itself: it can render after the page title appears, and
-# retryTapIfNoChange only retries on no-change, not on element-not-found.
-- extendedWaitUntil:
-    visible:
-      id: "consent-checkbox"
+# Scroll to the bottom of the form so the consent line and the Confirm button
+# are both on screen (tapOn does not auto-scroll; the consent control is the
+# "I agree" text, and Confirm sits below it).
+- scrollUntilVisible:
+    element:
+      text: "I agree"
+    direction: DOWN
     timeout: 10000
+
+# Tick consent by tapping "I agree" (Confirm is disabled until checked).
 - tapOn:
-    id: "consent-checkbox"
+    text: "I agree"
     retryTapIfNoChange: true
 
 # Submit directly — the "Confirm your details" dialog no longer exists.

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -50,18 +50,20 @@ tags:
     visible: "Add your personal details"
     timeout: 30000
 
-# Scroll to the bottom of the form so the consent line and the Confirm button
-# are both on screen (tapOn does not auto-scroll; the consent control is the
-# "I agree" text, and Confirm sits below it).
+# Scroll to the bottom of the form so the consent control and the Confirm
+# button are both on screen (tapOn does not auto-scroll).
 - scrollUntilVisible:
     element:
       text: "I agree"
     direction: DOWN
     timeout: 10000
 
-# Tick consent by tapping "I agree" (Confirm is disabled until checked).
+# Tick consent (Confirm is disabled until checked). The checkbox surfaces as a
+# value node reading "0" (unchecked) that flips to "1" when tapped — a more
+# reliable target than the "I agree" text, which also appears in the consent
+# paragraph. retryTapIfNoChange re-taps only if the value didn't flip.
 - tapOn:
-    text: "I agree"
+    text: "0"
     retryTapIfNoChange: true
 
 # Submit directly — the "Confirm your details" dialog no longer exists.

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -58,12 +58,10 @@ tags:
     direction: DOWN
     timeout: 10000
 
-# Tick consent (Confirm is disabled until checked). The checkbox surfaces as a
-# value node reading "0" (unchecked) that flips to "1" when tapped — a more
-# reliable target than the "I agree" text, which also appears in the consent
-# paragraph. retryTapIfNoChange re-taps only if the value didn't flip.
+# Tick consent by tapping the "I agree" checkbox label (Confirm is disabled
+# until checked). retryTapIfNoChange re-taps only if the check didn't register.
 - tapOn:
-    text: "0"
+    text: "I agree"
     retryTapIfNoChange: true
 
 # Submit directly — the "Confirm your details" dialog no longer exists, so

--- a/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
+++ b/maestro/pay-tests/.maestro/pay_multiple_options_kyc.yaml
@@ -66,9 +66,11 @@ tags:
     text: "0"
     retryTapIfNoChange: true
 
-# Submit directly — the "Confirm your details" dialog no longer exists.
+# Submit directly — the "Confirm your details" dialog no longer exists, so
+# "Confirm" is now unambiguous.
 - tapOn:
-    id: "identity-form-confirm-button"
+    text: "Confirm"
+    retryTapIfNoChange: true
 
 # Verify review screen shows the same token we selected
 - assertVisible:


### PR DESCRIPTION
## Part A — adapt native Maestro KYC flows to the redesigned `/collect` IC form

`WalletConnect/buyer-experience` PR #914 redesigns the hosted KYC webview (the `/collect` route that sample wallets open in a WebView). The redesign changes the strings/flow that the native Maestro `pay` flows in this repo rely on:

| Step | Before | After #914 |
|------|--------|-----------|
| Page title | "Add your personal details" | unchanged ✅ |
| Submit button | **"Add"** | **"Confirm"** |
| Confirmation dialog | "Confirm your details" popup | removed — Confirm submits directly |
| Consent | tapped Terms link string | inline checkbox `consent-checkbox` / aria-label "I agree"; Confirm disabled until checked |

### Changes
- `pay_multiple_options_kyc.yaml` — replace the `Add` → dialog → consent-link → `Confirm` chain with: tick `consent-checkbox`, then tap `identity-form-confirm-button`.
- `pay_cancel_from_kyc.yaml` — same replacement (server-side cancel + result-screen assertions unchanged).
- `pay_kyc_back_navigation.yaml` — **not touched** (only waits for the unchanged title; never submits).

### ⚠️ Sequencing — do not merge until #914 is deployed
The new steps only pass against an environment where buyer-experience **#914 is already deployed** to the env the sample wallets load their `/collect` webview from. The old steps pass only against the old form — they are mutually exclusive.

1. Merge & deploy buyer-experience #914.
2. Verify the new `/collect` form is live (open it manually).
3. Merge this PR.
4. Bump the pinned SHA in the 4 consumer repos (kotlin / swift / flutter / react-native-examples).

### ⚠️ Selector uncertainty (verify on a real WebView run)
Maestro matches WebView elements via the accessibility tree; `data-testid` is not guaranteed to surface as a Maestro `id`. Validate on a real run:
- Consent: prefer `id: "consent-checkbox"`. Fallback is labeled "I agree" — but **do not** use a bare `text: "I agree"` (the consent paragraph also contains "I agree" in quotes; disambiguate with `index`/longer substring). Keep `retryTapIfNoChange: true`.
- Confirm: prefer `id: "identity-form-confirm-button"`; fallback `text: "Confirm"` (now unambiguous).

Draft until the selectors are validated on a real run against a #914-deployed env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
