### PR TITLE
feat(metrics): exclude out-of-scope runs from KPIs via (skip-metrics) marker

### DIFF
--- a/metrics/scripts/lib.sh
+++ b/metrics/scripts/lib.sh
@@ -42,14 +42,9 @@ fetch_runs() {
     if [[ -z "$response" ]]; then
       break
     fi
-    # Exclude runs the workflow marked as out-of-scope for KPIs. Workflows add a
-    # "(skip-metrics)" marker to their run-name (surfaced here as `display_title`)
-    # for runs that shouldn't count toward any KPI (pass/flake/p95/bug-catches):
-    # draft-PR runs, and manual (workflow_dispatch) runs off the default branch.
-    # The decision lives in the workflow — where branch/draft context is free —
-    # so this stays a plain string match with no extra API calls. Filter AFTER
-    # computing `count` below so pagination still keys off the raw page size —
-    # otherwise a page that's mostly skipped would look short and stop paging early.
+    # Drop runs the workflow tagged "(skip-metrics)" in its run-name (here:
+    # display_title) — they shouldn't count toward any KPI. Filter AFTER computing
+    # `count` so pagination keys off the raw page size, not the post-filter size.
     local count
     count=$(printf '%s\n' "$response" | wc -l)
     printf '%s\n' "$response" | jq -c 'select((.display_title // "") | contains("(skip-metrics)") | not)'

--- a/metrics/scripts/lib.sh
+++ b/metrics/scripts/lib.sh
@@ -42,15 +42,17 @@ fetch_runs() {
     if [[ -z "$response" ]]; then
       break
     fi
-    # Exclude draft-PR runs. Workflows append a " (Draft)" marker to their
-    # run-name when triggered by a draft PR (github.event.pull_request.draft),
-    # which surfaces here as `display_title`. Draft runs are WIP and shouldn't
-    # count toward any KPI (pass/flake/p95/bug-catches). Filter AFTER computing
-    # `count` below so pagination still keys off the raw page size — otherwise a
-    # page that's mostly drafts would look short and stop paging early.
+    # Exclude runs the workflow marked as out-of-scope for KPIs. Workflows add a
+    # "(skip-metrics)" marker to their run-name (surfaced here as `display_title`)
+    # for runs that shouldn't count toward any KPI (pass/flake/p95/bug-catches):
+    # draft-PR runs, and manual (workflow_dispatch) runs off the default branch.
+    # The decision lives in the workflow — where branch/draft context is free —
+    # so this stays a plain string match with no extra API calls. Filter AFTER
+    # computing `count` below so pagination still keys off the raw page size —
+    # otherwise a page that's mostly skipped would look short and stop paging early.
     local count
     count=$(printf '%s\n' "$response" | wc -l)
-    printf '%s\n' "$response" | jq -c 'select((.display_title // "") | contains(" (Draft)") | not)'
+    printf '%s\n' "$response" | jq -c 'select((.display_title // "") | contains("(skip-metrics)") | not)'
     if [[ $count -lt 100 ]]; then
       break
     fi

--- a/metrics/scripts/lib.sh
+++ b/metrics/scripts/lib.sh
@@ -42,9 +42,15 @@ fetch_runs() {
     if [[ -z "$response" ]]; then
       break
     fi
-    printf '%s\n' "$response"
+    # Exclude draft-PR runs. Workflows append a " (Draft)" marker to their
+    # run-name when triggered by a draft PR (github.event.pull_request.draft),
+    # which surfaces here as `display_title`. Draft runs are WIP and shouldn't
+    # count toward any KPI (pass/flake/p95/bug-catches). Filter AFTER computing
+    # `count` below so pagination still keys off the raw page size — otherwise a
+    # page that's mostly drafts would look short and stop paging early.
     local count
     count=$(printf '%s\n' "$response" | wc -l)
+    printf '%s\n' "$response" | jq -c 'select((.display_title // "") | contains(" (Draft)") | not)'
     if [[ $count -lt 100 ]]; then
       break
     fi


### PR DESCRIPTION
## Why

The **rn** row on the E2E KPI dashboard hit **P95 PR feedback of 62m** (vs ~30m usual): one hung Android E2E job on a **draft PR** ran to its 60m timeout and, with only n=8 PR runs in the window, dominated the P95. More broadly, work-in-progress and ad-hoc runs shouldn't count toward KPIs at all:

- **Draft-PR runs** — WIP, not real feedback.
- **Manual (`workflow_dispatch`) runs off the default branch** — ad-hoc dev testing; the SDK repos have no branch filter, so these land in pass/flake today.
- **Scheduled / default-branch runs** — these *should* count and are unaffected.

## How

Workflows stamp a `(skip-metrics)` marker into their `run-name` for runs that are out of scope (draft PR, or `workflow_dispatch` off the default branch). It surfaces on the run as `display_title`. This PR filters those out **centrally in `fetch_runs`**, so every KPI script inherits it.

The exclusion *decision* lives in each workflow — where draft/branch context is free — which keeps the metric side a plain string match with **no extra API calls**.

### Correctness notes
- **Pagination preserved**: filtering happens after the raw page size is counted, so a page full of skipped runs won't stop paging early.
- **Non-marked runs untouched**: schedule/push/ready-PR/default-branch runs never carry the marker.
- **Opt-in per repo**: only repos that emit the marker are affected.

## Rollout

Requires each workflow to emit the marker. In progress:
- reown-com/react-native-examples (merged the draft-skip; marker swap to `(skip-metrics)` follow-up pending)
- reown-com/reown-kotlin#411
- reown-com/reown-swift#325
- reown-com/reown_flutter#392

Until a repo emits the marker, its behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)