### PR TITLE
feat(claude/terraform-plan-review): sticky per-environment comments

### DIFF
--- a/claude/terraform-plan-review/README.md
+++ b/claude/terraform-plan-review/README.md
@@ -114,6 +114,7 @@ permissions:
 | `model`                  | ❌       | `claude-sonnet-4-6` | Claude model to use for reviews                                  |
 | `terraform_plan_file`    | ✅       | -                            | Path to file containing the Terraform plan output                |
 | `terraform_plan_log_file`| ❌       | -                            | Path to file containing Terraform plan logs (warnings/errors)    |
+| `environment`            | ❌       | `$TF_WORKSPACE` or `default` | Environment/stage name keying the sticky plan comment (e.g. `staging`, `prod`) |
 
 ## Usage Examples
 
@@ -336,10 +337,18 @@ If you're using the `plan-terraform` composite action, you need to copy the plan
 
 The action posts a **concise summary** at the top of the comment with full details in a collapsible section to keep PRs clean and scannable.
 
+### Sticky Comments
+
+Comments are keyed per environment so re-runs (new pushes, PR edits) don't pile up:
+
+- The plan comment carries a hidden `<!-- claude-terraform-plan-review:<environment> -->` marker and is **updated in place** on re-runs
+- The previous Claude review for the same environment is **deleted** before a new review is posted, so only the latest verdict remains
+- The environment key comes from the `environment` input, falling back to `$TF_WORKSPACE`, then `default`. If you run plans for multiple environments on one PR without either, they will overwrite each other's plan comment — pass `environment` explicitly in that case.
+
 ### Summary (Always Visible)
 
 ```markdown
-## 📊 Terraform Plan Review
+## 📊 Terraform Plan Review (staging)
 
 **Summary:**
 - 5 resources to add, 0 to change, 3 to destroy

--- a/claude/terraform-plan-review/README.md
+++ b/claude/terraform-plan-review/README.md
@@ -343,7 +343,9 @@ Comments are keyed per environment so re-runs (new pushes, PR edits) don't pile 
 
 - The plan comment carries a hidden `<!-- claude-terraform-plan-review:<environment> -->` marker and is **updated in place** on re-runs
 - The previous Claude review for the same environment is **deleted** before a new review is posted, so only the latest verdict remains
-- The environment key comes from the `environment` input, falling back to `$TF_WORKSPACE`, then `default`. If you run plans for multiple environments on one PR without either, they will overwrite each other's plan comment — pass `environment` explicitly in that case.
+- The environment key comes from the `environment` input, falling back to `$TF_WORKSPACE`, then `default` (lowercased). If you run plans for multiple environments on one PR without either, they will overwrite each other's plan comment — pass `environment` explicitly in that case.
+
+**Upgrading note:** comments posted by older versions of this action (no hidden marker, no environment suffix in the review heading) are not recognized and will linger once next to the new sticky comments on PRs that were already open. This is one-time cosmetic noise; delete them manually if it bothers you. The cleanup deliberately only matches the environment-suffixed heading — a broader match would let concurrent per-environment runs delete each other's reviews.
 
 ### Summary (Always Visible)
 

--- a/claude/terraform-plan-review/action.yml
+++ b/claude/terraform-plan-review/action.yml
@@ -35,6 +35,8 @@ runs:
         ENVIRONMENT="${{ inputs.environment }}"
         ENVIRONMENT="${ENVIRONMENT:-$TF_WORKSPACE}"
         ENVIRONMENT="${ENVIRONMENT:-default}"
+        # Lowercase so casing drift across runs can't break the sticky match
+        ENVIRONMENT=$(printf '%s' "$ENVIRONMENT" | tr '[:upper:]' '[:lower:]')
         echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
     - name: Upload Terraform Plan to PR

--- a/claude/terraform-plan-review/action.yml
+++ b/claude/terraform-plan-review/action.yml
@@ -16,6 +16,10 @@ inputs:
   terraform_plan_log_file:
     description: "Optional: Path to file containing raw terraform plan logs (warnings/errors) for diagnostics"
     required: false
+  environment:
+    description: "Environment/stage name keying the sticky plan comment (e.g. staging, prod). Defaults to $TF_WORKSPACE if set, else 'default'."
+    required: false
+    default: ""
   allowed_bots:
     description: "Comma-separated bot actors allowed to trigger the review, or '*' for all bots"
     required: false
@@ -24,14 +28,27 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve environment key
+      id: env-key
+      shell: bash
+      run: |
+        ENVIRONMENT="${{ inputs.environment }}"
+        ENVIRONMENT="${ENVIRONMENT:-$TF_WORKSPACE}"
+        ENVIRONMENT="${ENVIRONMENT:-default}"
+        echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+
     - name: Upload Terraform Plan to PR
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        ENVIRONMENT: ${{ steps.env-key.outputs.environment }}
       run: |
+        export MARKER="<!-- claude-terraform-plan-review:${ENVIRONMENT} -->"
+
         # Create a comment with the plan attached
         {
-          echo "## 🤖 Terraform Plan Review Request"
+          echo "$MARKER"
+          echo "## 🤖 Terraform Plan Review Request (\`${ENVIRONMENT}\`)"
           echo ""
           echo "A Terraform plan has been generated and needs review. The plan is attached below:"
           echo ""
@@ -51,7 +68,7 @@ runs:
           echo '```'
           echo ""
           echo "</details>"
-          
+
           if [[ -n "${{ inputs.terraform_plan_log_file }}" && -f "${{ inputs.terraform_plan_log_file }}" ]]; then
             echo ""
             echo "<details><summary>Terraform Plan Logs (click to expand)</summary>"
@@ -67,23 +84,47 @@ runs:
             echo "</details>"
           fi
         } > /tmp/plan_comment.md
-        
-        # Post as a PR comment
+
+        # Update the existing sticky comment for this environment if present,
+        # otherwise create it. Keeps re-runs from piling up plan comments.
         if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --body-file /tmp/plan_comment.md || echo "Failed to post plan comment"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate --jq '.[] | select(.body | startswith(env.MARKER)) | .id' | sed -n 1p || true)
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+              --field body=@/tmp/plan_comment.md > /dev/null || echo "Failed to update plan comment"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --body-file /tmp/plan_comment.md || echo "Failed to post plan comment"
+          fi
         fi
-    
+
+    - name: Remove superseded Claude review
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REVIEW_HEADING: "## 📊 Terraform Plan Review (${{ steps.env-key.outputs.environment }})"
+      run: |
+        # Claude posts a fresh review comment per run; drop the previous one
+        # for this environment so only the latest verdict remains.
+        gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          --paginate \
+          --jq '.[] | select(.user.type == "Bot") | select(.user.login | ascii_downcase | contains("claude")) | select(.body | contains(env.REVIEW_HEADING)) | .id' \
+        | while read -r id; do
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/$id" || echo "Failed to delete comment $id"
+          done || echo "Failed to list previous Claude reviews"
+
     - name: Automatic PR Review with Claude
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         prompt: |
-          As a staff DevOps engineer, analyze the Terraform plan for PR #${{ github.event.pull_request.number }} in repo ${{ github.repository }}.
+          As a staff DevOps engineer, analyze the Terraform plan for the `${{ steps.env-key.outputs.environment }}` environment of PR #${{ github.event.pull_request.number }} in repo ${{ github.repository }}.
 
           IMPORTANT: The full Terraform plan is available at this file path: ${{ inputs.terraform_plan_file }}
-          
+
           To review the plan:
           1. Use bash commands to read the FULL plan file at ${{ inputs.terraform_plan_file }} (don't rely on the truncated PR comment)
           2. Compare the planned changes against the PR's code diff
@@ -95,8 +136,9 @@ runs:
 
           1. Start with a concise summary section (NOT in a details block)
           2. Put the full detailed analysis inside a collapsible <details> section
+          3. The top-level heading must be EXACTLY "## 📊 Terraform Plan Review (${{ steps.env-key.outputs.environment }})" — it is used to identify and replace superseded reviews
 
-          ## 📊 Terraform Plan Review
+          ## 📊 Terraform Plan Review (${{ steps.env-key.outputs.environment }})
 
           **Summary:**
           - X resources to add, Y to change, Z to destroy
@@ -108,7 +150,7 @@ runs:
 
           ### Plan Summary
           - X resources to add
-          - Y resources to change  
+          - Y resources to change
           - Z resources to destroy
           - Cost Impact: [Estimate if possible]
 


### PR DESCRIPTION
## Summary
Every CI re-run (push, PR title edit) appended a fresh "Terraform Plan Review Request" comment plus a Claude review **per environment**, burying terraform PRs in bot comments (e.g. WalletConnect/pay-core#1007 collected 16 bot comments from 4 runs × 2 stages).

## Changes
- Plan comment carries a hidden `<!-- claude-terraform-plan-review:<env> -->` marker and is updated in place on re-runs instead of appended
- Previous Claude review for the same environment is deleted before the new review posts, so only the latest verdict remains (matched via the required `## 📊 Terraform Plan Review (<env>)` heading)
- New optional `environment` input; defaults to `$TF_WORKSPACE` (already set per-stage by ci_workflows' `ci-plan-infra.yml`), then `default`
- Prompt now names the environment and pins the exact review heading

## Consumer rollout
Review jobs in other consumers run in artifact-download jobs without `TF_WORKSPACE`, so multi-root repos would collide on the `default` key (overwritten plan comment, cross-deleted reviews). Explicit `environment` PRs, safe to merge in either order (unknown composite inputs only warn):
- WalletConnect/pay-merchant-experience#770 (`inputs.working_directory`)
- WalletConnect/buyer-experience#947 (`monitoring` / `profiles-monitoring`)
- `WalletConnect/infra` and pay-core (`TF_WORKSPACE=wl-<stage>` via ci_workflows) need no change

## Test plan
- Push twice to a terraform-touching PR in a consumer repo (action is pinned `@master`): each stage should keep exactly one plan comment (edited) and one Claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
